### PR TITLE
Client connection timeout

### DIFF
--- a/client/src/main/java/com/vesoft/nebula/AbstractClient.java
+++ b/client/src/main/java/com/vesoft/nebula/AbstractClient.java
@@ -22,20 +22,24 @@ public abstract class AbstractClient implements Client {
     protected final int connectionRetry;
     protected final int executionRetry;
     protected final int timeout;
+    // Note that it doesn't affect AsyncClients
+    protected final int connectionTimeout;
     protected TProtocol protocol;
     protected TTransport transport;
 
     /**
      * The Constructor of Client.
      *
-     * @param addresses       The addresses of graph services.
-     * @param timeout         The timeout of RPC request.
-     * @param connectionRetry The number of retries when connection failure.
-     * @param executionRetry  The number of retries when execution failure.
+     * @param addresses          The addresses of graph services.
+     * @param timeout            The timeout of RPC request.
+     * @param connectionTimeout  The timeout of RPC request.
+     * @param connectionRetry    The number of retries when connection failure.
+     * @param executionRetry     The number of retries when execution failure.
      */
-    public AbstractClient(List<HostAndPort> addresses, int timeout,
+    public AbstractClient(List<HostAndPort> addresses, int timeout, int connectionTimeout,
                           int connectionRetry, int executionRetry) {
         checkArgument(timeout > 0);
+        checkArgument(connectionTimeout >= 0);
         checkArgument(connectionRetry > 0);
         checkArgument(executionRetry > 0);
         for (HostAndPort address : addresses) {
@@ -49,6 +53,7 @@ public abstract class AbstractClient implements Client {
 
         this.addresses = addresses;
         this.timeout = timeout;
+        this.connectionTimeout = connectionTimeout;
         this.connectionRetry = connectionRetry;
         this.executionRetry = executionRetry;
     }
@@ -59,8 +64,8 @@ public abstract class AbstractClient implements Client {
      * @param addresses The addresses of graph services.
      */
     public AbstractClient(List<HostAndPort> addresses) {
-        this(addresses, DEFAULT_TIMEOUT_MS, DEFAULT_CONNECTION_RETRY_SIZE,
-                DEFAULT_EXECUTION_RETRY_SIZE);
+        this(addresses, DEFAULT_TIMEOUT_MS, DEFAULT_CONN_TIMEOUT_MS, DEFAULT_CONNECTION_RETRY_SIZE,
+            DEFAULT_EXECUTION_RETRY_SIZE);
     }
 
     /**
@@ -71,12 +76,12 @@ public abstract class AbstractClient implements Client {
      */
     public AbstractClient(String host, int port) {
         this(Lists.newArrayList(HostAndPort.fromParts(host, port)), DEFAULT_TIMEOUT_MS,
-                DEFAULT_CONNECTION_RETRY_SIZE, DEFAULT_EXECUTION_RETRY_SIZE);
+            DEFAULT_CONN_TIMEOUT_MS, DEFAULT_CONNECTION_RETRY_SIZE, DEFAULT_EXECUTION_RETRY_SIZE);
     }
 
     public AbstractClient() {
         this(Lists.newArrayList(), DEFAULT_TIMEOUT_MS,
-                DEFAULT_CONNECTION_RETRY_SIZE, DEFAULT_EXECUTION_RETRY_SIZE);
+            DEFAULT_CONN_TIMEOUT_MS, DEFAULT_CONNECTION_RETRY_SIZE, DEFAULT_EXECUTION_RETRY_SIZE);
     }
 
     protected abstract int doConnect(List<HostAndPort> addresses) throws TException;

--- a/client/src/main/java/com/vesoft/nebula/AsyncAbstractClient.java
+++ b/client/src/main/java/com/vesoft/nebula/AsyncAbstractClient.java
@@ -24,7 +24,7 @@ public abstract class AsyncAbstractClient extends AbstractClient {
 
     public AsyncAbstractClient(List<HostAndPort> addresses, int timeout,
                                int connectionRetry, int executionRetry) {
-        super(addresses, timeout, connectionRetry, executionRetry);
+        super(addresses, timeout, DEFAULT_CONN_TIMEOUT_MS, connectionRetry, executionRetry);
     }
 
     public AsyncAbstractClient(List<HostAndPort> addresses) {

--- a/client/src/main/java/com/vesoft/nebula/Client.java
+++ b/client/src/main/java/com/vesoft/nebula/Client.java
@@ -29,6 +29,7 @@ public interface Client extends AutoCloseable, Serializable {
     }
 
     int DEFAULT_TIMEOUT_MS = 1000;
+    int DEFAULT_CONN_TIMEOUT_MS = 3000;
     int DEFAULT_CONNECTION_RETRY_SIZE = 3;
     int DEFAULT_EXECUTION_RETRY_SIZE = 3;
 

--- a/client/src/main/java/com/vesoft/nebula/Client.java
+++ b/client/src/main/java/com/vesoft/nebula/Client.java
@@ -14,7 +14,7 @@ import java.io.Serializable;
  */
 public interface Client extends AutoCloseable, Serializable {
 
-    public static enum NebulaCode {
+    enum NebulaCode {
         SUCCEEDED(0);
 
         int code;
@@ -23,21 +23,17 @@ public interface Client extends AutoCloseable, Serializable {
             return code;
         }
 
-        private NebulaCode() {
-
-        }
-
         NebulaCode(int code) {
             this.code = code;
         }
     }
 
-    public static final int DEFAULT_TIMEOUT_MS = 1000;
-    public static final int DEFAULT_CONNECTION_RETRY_SIZE = 3;
-    public static final int DEFAULT_EXECUTION_RETRY_SIZE = 3;
+    int DEFAULT_TIMEOUT_MS = 1000;
+    int DEFAULT_CONNECTION_RETRY_SIZE = 3;
+    int DEFAULT_EXECUTION_RETRY_SIZE = 3;
 
-    public int connect() throws TException;
+    int connect() throws TException;
 
-    public boolean isConnected();
+    boolean isConnected();
 
 }

--- a/client/src/main/java/com/vesoft/nebula/client/graph/GraphClientImpl.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/GraphClientImpl.java
@@ -36,7 +36,12 @@ public class GraphClientImpl extends AbstractClient implements GraphClient {
 
     public GraphClientImpl(List<HostAndPort> addresses, int timeout,
                            int connectionRetry, int executionRetry) {
-        super(addresses, timeout, connectionRetry, executionRetry);
+        this(addresses, timeout, DEFAULT_CONN_TIMEOUT_MS, connectionRetry, executionRetry);
+    }
+
+    public GraphClientImpl(List<HostAndPort> addresses, int timeout, int connTimeout,
+        int connectionRetry, int executionRetry) {
+        super(addresses, timeout, connTimeout, connectionRetry, executionRetry);
     }
 
     public GraphClientImpl(List<HostAndPort> addresses) {
@@ -52,7 +57,8 @@ public class GraphClientImpl extends AbstractClient implements GraphClient {
         Random random = new Random(System.currentTimeMillis());
         int position = random.nextInt(addresses.size());
         HostAndPort address = addresses.get(position);
-        transport = new TSocket(address.getHostText(), address.getPort(), timeout);
+        transport = new TSocket(address.getHostText(), address.getPort(), timeout,
+            connectionTimeout);
         transport.open();
         protocol = new TCompactProtocol(transport);
         client = new GraphService.Client(protocol);

--- a/client/src/main/java/com/vesoft/nebula/client/meta/MetaClientImpl.java
+++ b/client/src/main/java/com/vesoft/nebula/client/meta/MetaClientImpl.java
@@ -64,7 +64,12 @@ public class MetaClientImpl extends AbstractClient implements MetaClient {
 
     public MetaClientImpl(List<HostAndPort> addresses, int timeout,
                           int connectionRetry, int executionRetry) {
-        super(addresses, timeout, connectionRetry, executionRetry);
+        this(addresses, timeout, DEFAULT_CONN_TIMEOUT_MS, connectionRetry, executionRetry);
+    }
+
+    public MetaClientImpl(List<HostAndPort> addresses, int timeout, int connTimeout,
+        int connectionRetry, int executionRetry) {
+        super(addresses, timeout, connTimeout, connectionRetry, executionRetry);
     }
 
     public MetaClientImpl(List<HostAndPort> addresses) {
@@ -80,7 +85,8 @@ public class MetaClientImpl extends AbstractClient implements MetaClient {
         Random random = new Random(System.currentTimeMillis());
         int position = random.nextInt(addresses.size());
         HostAndPort address = addresses.get(position);
-        transport = new TSocket(address.getHostText(), address.getPort(), timeout);
+        transport = new TSocket(address.getHostText(), address.getPort(), timeout,
+            connectionTimeout);
         transport.open();
         protocol = new TCompactProtocol(transport);
         client = new MetaService.Client(protocol);


### PR DESCRIPTION
Clean unused code for com.vesoft.nebula.Client

Add connection timeout for Clients. The default timeout for TSocket is 0, which will block client infinitely when server behave strangely