### PR TITLE
modify slf4j-log4j12 to optional dependency

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -200,6 +200,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j-log4j12.version}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
delete slf4j-log4j12 dependency to prevent multiple slf4j binding classes.