### PR TITLE
On StorageClient close, should also release meta client.

### DIFF
--- a/client/src/main/java/com/vesoft/nebula/client/meta/MetaManager.java
+++ b/client/src/main/java/com/vesoft/nebula/client/meta/MetaManager.java
@@ -27,8 +27,6 @@ import org.slf4j.LoggerFactory;
 
 /**
  * MetaManager is a manager for meta info, such as spaces,tags and edges.
- * How to use:
- * MetaManager manager = MetaManager.getMetaManager(Arrays.asList(HostAddress(host, port)));
  */
 public class MetaManager implements MetaCache {
     private class SpaceInfo {
@@ -45,43 +43,22 @@ public class MetaManager implements MetaCache {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetaManager.class);
 
-    private static MetaClient metaClient;
-    private static MetaManager metaManager;
+    private MetaClient metaClient;
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
-
-    private MetaManager() {
-    }
 
     /**
      * init the meta info cache
-     * make sure this method is called before use metaManager
      */
-    private void init(List<HostAddress> address) throws TException {
+    public MetaManager(List<HostAddress> address) throws TException {
         metaClient = new MetaClient(address);
         metaClient.connect();
         fillMetaInfo();
     }
 
     /**
-     * only way to get a MetaManager object
-     */
-    public static MetaManager getMetaManager(List<HostAddress> address) throws TException {
-        if (metaManager == null) {
-            synchronized (MetaManager.class) {
-                if (metaManager == null) {
-                    metaManager = new MetaManager();
-                    metaManager.init(address);
-                }
-            }
-        }
-        return metaManager;
-    }
-
-    /**
      * close meta client
      */
     public void close() {
-        metaManager = null;
         metaClient.close();
     }
 

--- a/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
+++ b/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
@@ -79,7 +79,7 @@ public class StorageClient {
         connection.open(addresses.get(0), timeout);
         StoragePoolConfig config = new StoragePoolConfig();
         pool = new StorageConnPool(config);
-        metaManager = MetaManager.getMetaManager(addresses);
+        metaManager = new MetaManager(addresses);
         return true;
     }
 
@@ -1060,7 +1060,7 @@ public class StorageClient {
 
 
     /**
-     * release storage client and meta client
+     * release storage client
      */
     public void close() {
         if (pool != null) {

--- a/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
+++ b/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
@@ -1060,7 +1060,7 @@ public class StorageClient {
 
 
     /**
-     * release storage client
+     * release storage client and meta client
      */
     public void close() {
         if (pool != null) {
@@ -1068,6 +1068,9 @@ public class StorageClient {
         }
         if (connection != null) {
             connection.close();
+        }
+        if (metaManager != null) {
+            metaManager.close();
         }
     }
 

--- a/client/src/test/java/com/vesoft/nebula/client/meta/TestMetaManager.java
+++ b/client/src/test/java/com/vesoft/nebula/client/meta/TestMetaManager.java
@@ -22,7 +22,7 @@ public class TestMetaManager extends TestCase {
 
     public void setUp() throws Exception {
         MockNebulaGraph.initGraph();
-        metaManager = MetaManager.getMetaManager(
+        metaManager = new MetaManager(
                 Collections.singletonList(new HostAddress("127.0.0.1", 9559)));
     }
 
@@ -100,7 +100,7 @@ public class TestMetaManager extends TestCase {
     public void testMultiVersionSchema() {
         MockNebulaGraph.createMultiVersionTagAndEdge();
         metaManager.close();
-        metaManager = MetaManager.getMetaManager(
+        metaManager = new MetaManager(
                 Collections.singletonList(new HostAddress("127.0.0.1", 9559)));
         TagItem tagItem = metaManager.getTag("testMeta", "player");
         assert (tagItem.getVersion() == 1);


### PR DESCRIPTION
If User just use StorageClient, don't use MetaManager, When close StorageClient, then meta client is leaked, and in general, user don't know to use `MetaManager.getMetaManager(address).close()` to release meta client.
In my opinion, because MetaManager is a single instance, it should be just used at StorageClient, should be moved to storage package. If not, it shouldn't be single instance.