### PR TITLE
Prevent crashing app when any server is alive in V2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ There are the version correspondence between client and Nebula:
 
 ## Graph client example
 
-To connect to the `nebula-graphd` process of Nebula Graph v2.0:
+To connect to the `nebula-graphd` process of Nebula Graph v2.5:
 
 ```java
 NebulaPoolConfig nebulaPoolConfig = new NebulaPoolConfig();

--- a/README.md
+++ b/README.md
@@ -56,12 +56,13 @@ There are the version correspondence between client and Nebula:
 | Client version | Nebula Version |
 |:--------------:|:-------------------:|
 |     1.0.0      |       1.0.0         |
-|     1.0.1      |    1.1.0,1.2.0     |
-|     1.1.0      |    1.1.0,1.2.0     |
+|     1.0.1      |     1.1.0,1.2.0     |
+|     1.1.0      |     1.1.0,1.2.0     |
 |     1.2.0      | 1.1.0,1.2.0,1.2.1   |
 |    2.0.0-beta  |      2.0.0-beta     |
 |    2.0.0-rc1   |       2.0.0-rc1     |
-|    2.0.0       |      >= 2.0.0       |
+|  2.0.0/2.0.1   |    2.0.0/2.0.1      |
+|    2.5.0       |      >= 2.5.0       |
 |  2.0.0-SNAPSHOT|    2.0.0-nightly    |
 
 ## Graph client example

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vesoft</groupId>
         <artifactId>nebula</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.5.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.vesoft</groupId>
         <artifactId>nebula</artifactId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.5.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>com.vesoft</groupId>
     <artifactId>nebula</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.5.0</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Prevent crashing app on init time when just one server of cluster is down. Based on what I have seen, the client application could be live on runtime when there are any graphd server. but on init time it checks for all nodes of graphd and it is in opposite to high availability.