### PR TITLE
Ability to prevent application crash if any graphd server is running

### DIFF
--- a/client/src/main/java/com/vesoft/nebula/client/graph/NebulaPoolConfig.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/NebulaPoolConfig.java
@@ -21,35 +21,75 @@ public class NebulaPoolConfig {
     // 0 means never delete
     private int idleTime = 0;
 
+    // The interval time to check idle connection, unit ms, -1 means no check
+    private int intervalIdle = -1;
+
+    // The wait time to get idle connection, unit ms
+    private int waitTime = 0;
+
+    // The minimum rate of healthy servers to all servers. if 1 it means all servers should be available on init.
+    private double minClusterHealthRate = 1;
+
     public int getMinConnSize() {
         return minConnsSize;
     }
 
-    public void setMinConnSize(int minConnSize) {
+    public NebulaPoolConfig setMinConnSize(int minConnSize) {
         this.minConnsSize = minConnSize;
+        return this;
     }
 
     public int getMaxConnSize() {
         return maxConnsSize;
     }
 
-    public void setMaxConnSize(int maxConnSize) {
+    public NebulaPoolConfig setMaxConnSize(int maxConnSize) {
         this.maxConnsSize = maxConnSize;
+        return this;
     }
 
     public int getTimeout() {
         return timeout;
     }
 
-    public void setTimeout(int timeout) {
+    public NebulaPoolConfig setTimeout(int timeout) {
         this.timeout = timeout;
+        return this;
     }
 
     public int getIdleTime() {
         return idleTime;
     }
 
-    public void setIdleTime(int idleTime) {
+    public NebulaPoolConfig setIdleTime(int idleTime) {
         this.idleTime = idleTime;
+        return this;
+    }
+
+    public int getIntervalIdle() {
+        return intervalIdle;
+    }
+
+    public NebulaPoolConfig setIntervalIdle(int intervalIdle) {
+        this.intervalIdle = intervalIdle;
+        return this;
+    }
+
+    public int getWaitTime() {
+        return waitTime;
+    }
+
+    public NebulaPoolConfig setWaitTime(int waitTime) {
+        this.waitTime = waitTime;
+        return this;
+    }
+
+    public double getMinClusterHealthRate() {
+        return minClusterHealthRate;
+    }
+
+    public NebulaPoolConfig setMinClusterHealthRate(double minClusterHealthRate) {
+        this.minClusterHealthRate = minClusterHealthRate;
+        return this;
     }
 }

--- a/client/src/main/java/com/vesoft/nebula/client/graph/net/NebulaPool.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/net/NebulaPool.java
@@ -16,7 +16,9 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.pool2.impl.AbandonedConfig;
+import org.apache.commons.pool2.impl.BaseObjectPoolConfig;
 import org.apache.commons.pool2.impl.GenericObjectPool;
 import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
 import org.slf4j.Logger;
@@ -26,11 +28,13 @@ public class NebulaPool {
     private GenericObjectPool<SyncConnection> objectPool = null;
     private LoadBalancer loadBalancer;
     private final Logger log = LoggerFactory.getLogger(this.getClass());
-    // the wait time to get idle connection, unit ms
-    private final int waitTime = 60 * 1000;
+    // The wait time to get idle connection, unit ms
+    private int waitTime = 0;
+    private final AtomicBoolean hasInit = new AtomicBoolean(false);
+    private final AtomicBoolean isClosed = new AtomicBoolean(false);
 
     private List<HostAddress> hostToIp(List<HostAddress> addresses)
-        throws UnknownHostException {
+            throws UnknownHostException {
         List<HostAddress> newAddrs = new ArrayList<>();
         for (HostAddress addr : addresses) {
             String ip = InetAddress.getByName(addr.getHost()).getHostAddress();
@@ -42,38 +46,58 @@ public class NebulaPool {
     private void checkConfig(NebulaPoolConfig config) {
         if (config.getIdleTime() < 0) {
             throw new InvalidConfigException(
-                "Config idleTime:" + config.getIdleTime() + " is illegal");
+                    "Config idleTime:" + config.getIdleTime() + " is illegal");
         }
 
         if (config.getMaxConnSize() <= 0) {
             throw new InvalidConfigException(
-                "Config maxConnSize:" + config.getMaxConnSize() + " is illegal");
+                    "Config maxConnSize:" + config.getMaxConnSize() + " is illegal");
         }
 
         if (config.getMinConnSize() < 0 || config.getMinConnSize() > config.getMaxConnSize()) {
             throw new InvalidConfigException(
-                "Config minConnSize:" + config.getMinConnSize() + " is illegal");
+                    "Config minConnSize:" + config.getMinConnSize() + " is illegal");
         }
 
         if (config.getTimeout() < 0) {
             throw new InvalidConfigException(
-                "Config timeout:" + config.getTimeout() + " is illegal");
+                    "Config timeout:" + config.getTimeout() + " is illegal");
+        }
+
+        if (config.getWaitTime() < 0) {
+            throw new InvalidConfigException(
+                    "Config waitTime:" + config.getWaitTime() + " is illegal");
         }
     }
 
+    /**
+     * @param addresses the graphd services addresses
+     * @param config the config for the pool
+     * @return boolean if all graph services are ok, return true,
+     *         if some of them broken return false
+     * @throws UnknownHostException if host address is illegal
+     * @throws InvalidConfigException if config is illegal
+     */
     public boolean init(List<HostAddress> addresses, NebulaPoolConfig config)
-        throws UnknownHostException, InvalidConfigException {
+            throws UnknownHostException, InvalidConfigException {
+        checkInit();
+        hasInit.set(true);
         checkConfig(config);
+        this.waitTime = config.getWaitTime();
         List<HostAddress> newAddrs = hostToIp(addresses);
-        this.loadBalancer = new RoundRobinLoadBalancer(newAddrs, config.getTimeout());
+        this.loadBalancer = new RoundRobinLoadBalancer(newAddrs, config.getTimeout(), config.getMinClusterHealthRate());
         ConnObjectPool objectPool = new ConnObjectPool(this.loadBalancer, config);
         this.objectPool = new GenericObjectPool<>(objectPool);
         GenericObjectPoolConfig objConfig = new GenericObjectPoolConfig();
         objConfig.setMinIdle(config.getMinConnSize());
-        objConfig.setMaxIdle(config.getMinConnSize());
+        objConfig.setMaxIdle(config.getMaxConnSize());
         objConfig.setMaxTotal(config.getMaxConnSize());
-        objConfig.setMinEvictableIdleTimeMillis(
-                config.getIdleTime() <= 0 ? Long.MAX_VALUE : config.getIdleTime());
+        objConfig.setTimeBetweenEvictionRunsMillis(config.getIntervalIdle() <= 0
+                ? BaseObjectPoolConfig.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS
+                : config.getIntervalIdle());
+        objConfig.setSoftMinEvictableIdleTimeMillis(config.getIdleTime() <= 0
+                ? BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS
+                : config.getIdleTime());
         this.objectPool.setConfig(objConfig);
 
         AbandonedConfig abandonedConfig = new AbandonedConfig();
@@ -82,45 +106,88 @@ public class NebulaPool {
         return objectPool.init();
     }
 
+    /**
+     * close the pool, all connections will be closed
+     */
     public void close() {
+        checkClosed();
+        isClosed.set(true);
         this.loadBalancer.close();
         this.objectPool.close();
     }
 
+    /**
+     * get a session from the NebulaPool
+     * @param userName the userName to authenticate with nebula-graph
+     * @param password the password to authenticate with nebula-graph
+     * @param reconnect whether to retry after the connection is disconnected
+     * @return Session
+     * @throws NotValidConnectionException if get connection failed
+     * @throws IOErrorException if get unexpected exception
+     * @throws AuthFailedException if authenticate failed
+     */
     public Session getSession(String userName, String password, boolean reconnect)
             throws NotValidConnectionException, IOErrorException, AuthFailedException {
+        checkNoInitAndClosed();
+        SyncConnection connection = null;
         try {
-            SyncConnection connection = getConnection();
+            connection = getConnection();
             AuthResult authResult = connection.authenticate(userName, password);
             return new Session(connection, authResult, this, reconnect);
-        } catch (NotValidConnectionException | AuthFailedException | IOErrorException e) {
-            throw e;
-        } catch (IllegalStateException e) {
-            throw new NotValidConnectionException(e.getMessage());
         } catch (Exception e) {
-            throw new IOErrorException(IOErrorException.E_UNKNOWN, e.getMessage());
+            // if get the connection succeeded, but authenticate failed,
+            // needs to return connection to pool
+            if (connection != null) {
+                setInvalidateConnection(connection);
+            }
+            throw e;
         }
     }
 
+    /**
+     * Get the number of connections was used by users
+     * @return the active connection number
+     */
     public int getActiveConnNum() {
+        checkNoInitAndClosed();
         return objectPool.getNumActive();
     }
 
+    /**
+     * Get the number of free connections in the pool
+     * @return the idle connection number
+     */
     public int getIdleConnNum() {
+        checkNoInitAndClosed();
         return objectPool.getNumIdle();
     }
 
+    /**
+     * Get the number of waits in a waiting get connection
+     * @return the waiting connection number
+     */
     public int getWaitersNum() {
+        checkNoInitAndClosed();
         return objectPool.getNumWaiters();
     }
 
-    public void updateServerStatus() {
+    /**
+     * Update the services' status when the connection is broken,
+     * it is called by Session and NebulaPool
+     */
+    protected void updateServerStatus() {
+        checkNoInitAndClosed();
         if (objectPool.getFactory() instanceof ConnObjectPool) {
             ((ConnObjectPool)objectPool.getFactory()).updateServerStatus();
         }
     }
 
+    /**
+     * Set the connection is invalidate, and the object pool will destroy it
+     * @param connection the invalidate connection
+     */
     protected void setInvalidateConnection(SyncConnection connection) {
+        checkNoInitAndClosed();
         try {
             objectPool.invalidateObject(connection);
         } catch (Exception e) {
@@ -128,53 +195,47 @@ public class NebulaPool {
         }
     }
 
+    /**
+     * Return the connection to object pool
+     * @param connection the return connection
+     */
     protected void returnConnection(SyncConnection connection) {
+        checkNoInitAndClosed();
         objectPool.returnObject(connection);
     }
 
-    protected SyncConnection getConnection() throws NotValidConnectionException, IOErrorException {
-        // If no idle connection, try once
-        int idleConnNum = getIdleConnNum();
-        int retry = idleConnNum == 0 ? 1 : idleConnNum;
-        SyncConnection connection = null;
-        boolean hasOkConn = false;
+    protected SyncConnection getConnection() throws NotValidConnectionException {
+        checkNoInitAndClosed();
         try {
-            while (retry-- > 0) {
-                connection = objectPool.borrowObject(waitTime);
-                if (connection == null) {
-                    continue;
-                }
-                if (!connection.ping()) {
-                    log.info("The connection is broken, set invalidateObject");
-                    setInvalidateConnection(connection);
-                    continue;
-                }
-                hasOkConn = true;
-                break;
-            }
-            // All idle connections are broken, so need to create new one
-            if (!hasOkConn) {
-                connection = objectPool.borrowObject(waitTime);
-                if (connection == null) {
-                    throw new NotValidConnectionException("Get null connection from the pool");
-                }
-                if (!connection.ping()) {
-                    log.info("The connection is broken, set invalidateObject");
-                    setInvalidateConnection(connection);
-                    throw new NotValidConnectionException("The connection ping failed.");
-                }
-                log.info("Create new connection");
-            }
-            log.info(String.format("Get connection to %s:%d",
-                    connection.getServerAddress().getHost(),
-                    connection.getServerAddress().getPort()));
-            return connection;
-        } catch (NotValidConnectionException | IOErrorException e) {
-            throw e;
-        } catch (IllegalStateException e) {
-            throw new NotValidConnectionException(e.getMessage());
+            return objectPool.borrowObject(waitTime);
         } catch (Exception e) {
-            throw new IOErrorException(IOErrorException.E_UNKNOWN, e.getMessage());
+            throw new NotValidConnectionException(e.getMessage());
+        }
+    }
+
+    private void checkNoInit() throws RuntimeException {
+        if (!hasInit.get()) {
+            throw new RuntimeException(
+                    "The pool has not been initialized, please initialize it first.");
+        }
+    }
+
+    private void checkInit() throws RuntimeException {
+        if (hasInit.get()) {
+            throw new RuntimeException(
+                    "The pool has already been initialized. "
+                            + "Please do not initialize the pool repeatedly.");
+        }
+    }
+
+    private void checkNoInitAndClosed() throws RuntimeException {
+        checkNoInit();
+        checkClosed();
+    }
+
+    private void checkClosed() throws RuntimeException {
+        if (isClosed.get()) {
+            throw new RuntimeException("The pool has closed. Couldn't use again.");
         }
     }
 }


### PR DESCRIPTION
I see in current code of v2.5, it has a problem in its code. when I adjust some servers as graphd in my config, client checks to have ping to all servers. It is ok. but now (after some days) one of my server going down and after one day my application going to restarted. It can't goes up and running because it crashes due to "servers are broken". Although there is just one down server, it stops.
So I added a new parameter to nebulaConfig, named minClusterHealthRate rate. As it is clear, when it is 1 (default), it means all servers should be alive on init time, but when you have 10 graphd server and the rate is 0.8 and just one of your server is down it continues to init stage and runs successfully. 