### PR TITLE
set check connection default open

### DIFF
--- a/client/src/main/java/com/vesoft/nebula/client/graph/net/NebulaPool.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/net/NebulaPool.java
@@ -94,6 +94,10 @@ public class NebulaPool {
         objConfig.setMinIdle(config.getMinConnSize());
         objConfig.setMaxIdle(config.getMaxConnSize());
         objConfig.setMaxTotal(config.getMaxConnSize());
+        objConfig.setTestOnBorrow(true);
+        objConfig.setTestOnReturn(true);
+        objConfig.setTestWhileIdle(true);
+        objConfig.setTestOnCreate(true);
         objConfig.setTimeBetweenEvictionRunsMillis(config.getIntervalIdle() <= 0
             ? BaseObjectPoolConfig.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS
             : config.getIntervalIdle());


### PR DESCRIPTION
#401 
prevent the exception like this"IOErrorException: Cannot write to null outputStream"

this error causeby the connection is broken ,for example network problem 

ps:you should release session when see the exception like "IOErrorException: Cannot write to null outputStream"

SessionWrapper.class execute method can catch the exception and release session