### PR TITLE
remove fastjosn for package

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -250,6 +250,7 @@
             <groupId>com.alibaba</groupId>
             <artifactId>fastjson</artifactId>
             <version>${fastjson.version}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -127,5 +127,10 @@
             <artifactId>commons-csv</artifactId>
             <version>1.7</version>
         </dependency>
+        <dependency>
+            <groupId>com.alibaba</groupId>
+            <artifactId>fastjson</artifactId>
+            <version>1.2.78</version>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
close https://github.com/vesoft-inc/nebula-java/issues/421

use `test` scope for fastjson, then user cannot use it outside nebula client unless users import it by themselves.