### PR TITLE
update slf4j-log4j12 dependency's scope to test

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -214,6 +214,7 @@
             <artifactId>slf4j-log4j12</artifactId>
             <version>${slf4j-log4j12.version}</version>
             <optional>true</optional>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
remove log4j in client package, just use it in test.
If users want to print log info for client, they should import slf4j's implement framework (slf4j-log4j12 or slf4j-logback) by themselves in business code.
