### PR TITLE
Fix host validation to support domain name

### DIFF
--- a/client/src/main/java/com/vesoft/nebula/client/meta/AbstractMetaClient.java
+++ b/client/src/main/java/com/vesoft/nebula/client/meta/AbstractMetaClient.java
@@ -9,6 +9,7 @@ import com.facebook.thrift.protocol.TProtocol;
 import com.facebook.thrift.transport.TTransport;
 import com.google.common.base.Preconditions;
 import com.google.common.net.InetAddresses;
+import com.google.common.net.InternetDomainName;
 import com.vesoft.nebula.client.graph.data.HostAddress;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -32,7 +33,7 @@ public class AbstractMetaClient {
             String host = InetAddress.getByName(address.getHost()).getHostAddress();
             int port = address.getPort();
             // check if the address is a valid ip address or uri address and port is valid
-            if ((!InetAddresses.isInetAddress(host) || !InetAddresses.isUriInetAddress(host))
+            if ((!InetAddresses.isInetAddress(host) || !InetAddresses.isUriInetAddress(host) || !InternetDomainName.isValid(host))
                     || (port <= 0 || port >= 65535)) {
                 throw new IllegalArgumentException(String.format("%s:%d is not a valid address",
                         host, port));

--- a/client/src/main/java/com/vesoft/nebula/client/meta/AbstractMetaClient.java
+++ b/client/src/main/java/com/vesoft/nebula/client/meta/AbstractMetaClient.java
@@ -32,8 +32,10 @@ public class AbstractMetaClient {
         for (HostAddress address : addresses) {
             String host = InetAddress.getByName(address.getHost()).getHostAddress();
             int port = address.getPort();
-            // check if the address is a valid ip address or uri address and port is valid
-            if ((!InetAddresses.isInetAddress(host) || !InetAddresses.isUriInetAddress(host) || !InternetDomainName.isValid(host))
+            // check if the address is a valid ip, uri address or domain name and port is valid
+            if (!(InetAddresses.isInetAddress(host)
+                        || InetAddresses.isUriInetAddress(host)
+                        || InternetDomainName.isValid(host))
                     || (port <= 0 || port >= 65535)) {
                 throw new IllegalArgumentException(String.format("%s:%d is not a valid address",
                         host, port));


### PR DESCRIPTION
close: https://github.com/vesoft-inc/nebula-algorithm/issues/42

This validation check only allowed IP format hosts, the domain name
should be supported on both thrift and HostAndPort.

This is blocking the nebula graph in K8s from using spark/java clients.

ref:
- https://github.com/google/guava/blob/master/guava/src/com/google/common/net/HostAndPort.java
