### PR TITLE
setStorageAddresses support to optionally override storage addresses

### DIFF
--- a/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
+++ b/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
@@ -579,7 +579,6 @@ public class StorageClient {
             partScanInfoSet.add(new PartScanInfo(part, new HostAddress(leader.getHost(),
                     leader.getPort())));
         }
-        List<HostAddress> addrs = getStorageAddresses();
 
         long tag = metaManager.getTag(spaceName, tagName).getTag_id();
         List<byte[]> props = new ArrayList<>();
@@ -607,6 +606,7 @@ public class StorageClient {
                 .setEnd_time(endTime)
                 .setEnable_read_from_follower(allowReadFromFollower);
 
+        List<HostAddress> addrs = getStorageAddresses();
         return doScanVertex(spaceName, tagName, partScanInfoSet, request, addrs, allowPartSuccess);
     }
 
@@ -1035,7 +1035,6 @@ public class StorageClient {
             partScanInfoSet.add(new PartScanInfo(part, new HostAddress(leader.getHost(),
                     leader.getPort())));
         }
-        List<HostAddress> addrs = getStorageAddresses();
         List<byte[]> props = new ArrayList<>();
         props.add("_src".getBytes());
         props.add("_dst".getBytes());
@@ -1066,6 +1065,7 @@ public class StorageClient {
                 .setEnd_time(endTime)
                 .setEnable_read_from_follower(allowReadFromFollower);
 
+        List<HostAddress> addrs = getStorageAddresses();
         return doScanEdge(spaceName, edgeName, partScanInfoSet, request, addrs, allowPartSuccess);
     }
 

--- a/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
+++ b/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
@@ -32,7 +32,8 @@ public class StorageClient {
     private final GraphStorageConnection connection;
     private StorageConnPool pool;
     private MetaManager metaManager;
-    private final List<HostAddress> addresses;
+    private final List<HostAddress> addresses; // meta addresses
+    private List<HostAddress> storageAddresses = new ArrayList<>();
     private int timeout = 10000; // ms
     private int connectionRetry = 3;
     private int executionRetry = 1;
@@ -107,6 +108,31 @@ public class StorageClient {
         return true;
     }
 
+    /**
+     * Set Storage Addresses.
+     */
+
+    public void setStorageAddresses(List<HostAddress> storageAddresses) {
+        this.storageAddresses = storageAddresses;
+    }
+
+    /**
+     * Get Storage Addresses.
+     * if storageAddresses is empty, fetch with listHosts()
+     * 
+     * @return an arrayList of HostAddress
+     */
+
+    public List<HostAddress> getStorageAddresses() {
+        if (storageAddresses.isEmpty()) {
+            List<HostAddress> addrs = new ArrayList<>();
+            for (HostAddr addr : metaManager.listHosts()) {
+                addrs.add(new HostAddress(addr.getHost(), addr.getPort()));
+            }
+            return addrs;
+        }
+        return storageAddresses;
+    }
 
     /**
      * scan vertex of all parts with specific return cols, if returnCols is an empty list, then
@@ -553,10 +579,7 @@ public class StorageClient {
             partScanInfoSet.add(new PartScanInfo(part, new HostAddress(leader.getHost(),
                     leader.getPort())));
         }
-        List<HostAddress> addrs = new ArrayList<>();
-        for (HostAddr addr : metaManager.listHosts()) {
-            addrs.add(new HostAddress(addr.getHost(), addr.getPort()));
-        }
+        List<HostAddress> addrs = getStorageAddresses();
 
         long tag = metaManager.getTag(spaceName, tagName).getTag_id();
         List<byte[]> props = new ArrayList<>();
@@ -1012,10 +1035,7 @@ public class StorageClient {
             partScanInfoSet.add(new PartScanInfo(part, new HostAddress(leader.getHost(),
                     leader.getPort())));
         }
-        List<HostAddress> addrs = new ArrayList<>();
-        for (HostAddr addr : metaManager.listHosts()) {
-            addrs.add(new HostAddress(addr.getHost(), addr.getPort()));
-        }
+        List<HostAddress> addrs = getStorageAddresses();
         List<byte[]> props = new ArrayList<>();
         props.add("_src".getBytes());
         props.add("_dst".getBytes());

--- a/examples/src/main/java/com/vesoft/nebula/examples/StorageClientExample.java
+++ b/examples/src/main/java/com/vesoft/nebula/examples/StorageClientExample.java
@@ -5,6 +5,7 @@
 
 package com.vesoft.nebula.examples;
 
+import com.vesoft.nebula.client.graph.data.HostAddress;
 import com.vesoft.nebula.client.storage.StorageClient;
 import com.vesoft.nebula.client.storage.data.EdgeTableRow;
 import com.vesoft.nebula.client.storage.data.VertexRow;
@@ -25,6 +26,12 @@ public class StorageClientExample {
     public static void main(String[] args) {
         // input params are the metad's ip and port
         StorageClient client = new StorageClient("127.0.0.1", 9559);
+
+        // optionally we could set the storage hosts addresses
+        // List<HostAddress> storageAddresses = Arrays.asList(
+        //            new HostAddress("127.0.0.1", 9779));
+        // client.setStorageAddresses(storageAddresses)
+
         try {
             client.connect();
         } catch (Exception e) {


### PR DESCRIPTION
This enables https://github.com/vesoft-inc/nebula-spark-connector/issues/39 , where we could make spark projects(spark-c, exchange, algorithm) running outside namespace/cluster of Nebula Graph Cluster in K8s being work together with Nebula(including the DBaaS).