### PR TITLE
fix the leader state for CANDIDATE meta role

### DIFF
--- a/client/src/main/java/com/vesoft/nebula/client/meta/MetaClient.java
+++ b/client/src/main/java/com/vesoft/nebula/client/meta/MetaClient.java
@@ -168,11 +168,14 @@ public class MetaClient extends AbstractMetaClient {
         }
     }
 
-    private void freshClient(HostAddr leader)
-            throws TTransportException {
+    private void freshClient(HostAddr leader) throws TTransportException {
         close();
         try {
-            getClient(leader.getHost(), leader.getPort());
+            if (leader.getHost() == null || "".equals(leader.getHost())) {
+                doConnect();
+            } else {
+                getClient(leader.getHost(), leader.getPort());
+            }
         } catch (ClientServerIncompatibleException e) {
             LOGGER.error(e.getMessage());
         }


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 
fix https://github.com/vesoft-inc/nebula-java/issues/409

#### Description:


## How do you solve it?
When the leader host in response is empty, then fresh the meta client with input addresses. When the leader host is not empty, just use the leader host to update the meta client.


## Special notes for your reviewer, ex. impact of this fix, design document, etc:


