### PR TITLE
enhancement:support more type value as parameter in session.value2Nvalue

### DIFF
--- a/client/src/main/java/com/vesoft/nebula/client/graph/net/Session.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/net/Session.java
@@ -434,9 +434,9 @@ public class Session implements Serializable, AutoCloseable {
     public static Value value2Nvalue(Object value) throws UnsupportedOperationException {
         try {
             if (value == null) {
-                Value nValue = new Value();
-                nValue.setNVal(NullType.__NULL__);
-                return nValue;
+                Value nullValue = new Value();
+                nullValue.setNVal(NullType.__NULL__);
+                return nullValue;
             }
             Class<?> type = value.getClass();
             Setter<Object> setter = LEAF_TYPE_AND_SETTER.get(type);
@@ -489,7 +489,7 @@ public class Session implements Serializable, AutoCloseable {
             put(DataSet.class, (Setter<DataSet>) Value::gVal);
             put(Geography.class, (Setter<Geography>) Value::ggVal);
             put(Duration.class, (Setter<Duration>) Value::duVal);
-       }};
+        }};
 
     /**
      * some value setter for java type (complex java type include collections or date) that need
@@ -535,12 +535,12 @@ public class Session implements Serializable, AutoCloseable {
                 Field[] declaredFields = paramType.getDeclaredFields();
                 for (Field declaredField : declaredFields) {
                     pojoFields.put(declaredField.getName(),
-                      value2Nvalue(ReflectUtil.getValue(obj, declaredField)));
+                        value2Nvalue(ReflectUtil.getValue(obj, declaredField)));
                 }
                 value.setMVal(map2Nmap(pojoFields));
                 return value;
             });
-       }};
+        }};
 
     interface Setter<T> {
 

--- a/client/src/main/java/com/vesoft/nebula/util/ReflectUtil.java
+++ b/client/src/main/java/com/vesoft/nebula/util/ReflectUtil.java
@@ -20,67 +20,66 @@ import java.util.Set;
  * <br>Now is history!
  */
 public class ReflectUtil {
-
-  /**
-   * Break through the access rights of the object 
-   *     and obtain the specified field value.
-   *     
-   * @param o object of field value source
-   * @param field field used for get value
-   * @return field value in obj
-   * @throws IllegalAccessException 
-   */
-  public static Object getValue(Object o, Field field) {
-    try {
-      boolean accessible = field.isAccessible();
-      if (accessible) {
-        return field.get(o);
-      } else {
-        field.setAccessible(true);
-        Object value = field.get(o);
-        field.setAccessible(false);
-        return value;
-      }
-    } catch (IllegalAccessException e) {
-      throw new RuntimeException(e);
-    }
-  }
   
-  /**
-   * Determine whether parentType is paramType or its parent class or interface
-   * 
-   * @param paramType type to be determined - subclass
-   * @param parentType type to be determined - parent class or interface
-   * @return whether paramType is a subclass or implementation class of parentType
-   */
-  public static boolean isCurrentTypeOrParentType(Class<?> paramType, Class<?> parentType) {
-    if (paramType == parentType) {
-      return true;
+    /**
+     * Break through the access rights of the object 
+     *     and obtain the specified field value.
+     *     
+     * @param o object of field value source
+     * @param field field used for get value
+     * @return field value in obj
+     */
+    public static Object getValue(Object o, Field field) {
+        try {
+          boolean accessible = field.isAccessible();
+          if (accessible) {
+              return field.get(o);
+          } else {
+              field.setAccessible(true);
+              Object value = field.get(o);
+              field.setAccessible(false);
+              return value;
+          }
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
     }
-    Set<Class<?>> parentTypes = getParentTypes(paramType);
-    return parentTypes.contains(parentType);
-  }
-
-  /**
-   * Get the super class and interface type collection according to paramType.
-   * 
-   * @param paramType subclass type.
-   * @return super class and interface.
-   */
-  public static Set<Class<?>> getParentTypes(Class<?> paramType) {
-    if (paramType == null) {
-      return Collections.EMPTY_SET;
+    
+    /**
+     * Determine whether parentType is paramType or its parent class or interface
+     * 
+     * @param paramType type to be determined - subclass
+     * @param parentType type to be determined - parent class or interface
+     * @return whether paramType is a subclass or implementation class of parentType
+     */
+    public static boolean isCurrentTypeOrParentType(Class<?> paramType, Class<?> parentType) {
+        if (paramType == parentType) {
+            return true;
+        }
+        Set<Class<?>> parentTypes = getParentTypes(paramType);
+        return parentTypes.contains(parentType);
     }
-    List<Class<?>> interfaces = Arrays.asList(paramType.getInterfaces());
-    Set<Class<?>> parents = new HashSet<>(interfaces);
-
-    for (Class<?> anInterface : interfaces) {
-      parents.addAll(getParentTypes(anInterface));
+  
+    /**
+     * Get the super class and interface type collection according to paramType.
+     * 
+     * @param paramType subclass type.
+     * @return super class and interface.
+     */
+    public static Set<Class<?>> getParentTypes(Class<?> paramType) {
+        if (paramType == null) {
+            return Collections.EMPTY_SET;
+        }
+        List<Class<?>> interfaces = Arrays.asList(paramType.getInterfaces());
+        Set<Class<?>> parents = new HashSet<>(interfaces);
+    
+        for (Class<?> anInterface : interfaces) {
+            parents.addAll(getParentTypes(anInterface));
+        }
+    
+        Class<?> superclass = paramType.getSuperclass();
+        parents.add(superclass);
+        parents.addAll(getParentTypes(superclass));
+        return parents;
     }
-
-    Class<?> superclass = paramType.getSuperclass();
-    parents.add(superclass);
-    parents.addAll(getParentTypes(superclass));
-    return parents;
-  }
 }

--- a/client/src/main/java/com/vesoft/nebula/util/ReflectUtil.java
+++ b/client/src/main/java/com/vesoft/nebula/util/ReflectUtil.java
@@ -31,15 +31,15 @@ public class ReflectUtil {
      */
     public static Object getValue(Object o, Field field) {
         try {
-          boolean accessible = field.isAccessible();
-          if (accessible) {
-              return field.get(o);
-          } else {
-              field.setAccessible(true);
-              Object value = field.get(o);
-              field.setAccessible(false);
-              return value;
-          }
+            boolean accessible = field.isAccessible();
+            if (accessible) {
+                return field.get(o);
+            } else {
+                field.setAccessible(true);
+                Object value = field.get(o);
+                field.setAccessible(false);
+                return value;
+            }
         } catch (IllegalAccessException e) {
             throw new RuntimeException(e);
         }

--- a/client/src/main/java/com/vesoft/nebula/util/ReflectUtil.java
+++ b/client/src/main/java/com/vesoft/nebula/util/ReflectUtil.java
@@ -1,0 +1,86 @@
+/* Copyright (c) 2023 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+package com.vesoft.nebula.util;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+
+/**
+ * The util of reflect
+ *
+ * @author yeweicheng
+ * <br>Now is history!
+ */
+public class ReflectUtil {
+
+  /**
+   * Break through the access rights of the object 
+   *     and obtain the specified field value.
+   *     
+   * @param o object of field value source
+   * @param field field used for get value
+   * @return field value in obj
+   * @throws IllegalAccessException 
+   */
+  public static Object getValue(Object o, Field field) {
+    try {
+      boolean accessible = field.isAccessible();
+      if (accessible) {
+        return field.get(o);
+      } else {
+        field.setAccessible(true);
+        Object value = field.get(o);
+        field.setAccessible(false);
+        return value;
+      }
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+  
+  /**
+   * Determine whether parentType is paramType or its parent class or interface
+   * 
+   * @param paramType type to be determined - subclass
+   * @param parentType type to be determined - parent class or interface
+   * @return whether paramType is a subclass or implementation class of parentType
+   */
+  public static boolean isCurrentTypeOrParentType(Class<?> paramType, Class<?> parentType) {
+    if (paramType == parentType) {
+      return true;
+    }
+    Set<Class<?>> parentTypes = getParentTypes(paramType);
+    return parentTypes.contains(parentType);
+  }
+
+  /**
+   * Get the super class and interface type collection according to paramType.
+   * 
+   * @param paramType subclass type.
+   * @return super class and interface.
+   */
+  public static Set<Class<?>> getParentTypes(Class<?> paramType) {
+    if (paramType == null) {
+      return Collections.EMPTY_SET;
+    }
+    List<Class<?>> interfaces = Arrays.asList(paramType.getInterfaces());
+    Set<Class<?>> parents = new HashSet<>(interfaces);
+
+    for (Class<?> anInterface : interfaces) {
+      parents.addAll(getParentTypes(anInterface));
+    }
+
+    Class<?> superclass = paramType.getSuperclass();
+    parents.add(superclass);
+    parents.addAll(getParentTypes(superclass));
+    return parents;
+  }
+}


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [ ] bug
- [ ] feature
- [x] enhancement

> The original push request is #461

## What problem(s) does this PR solve?
#### Description:
When executeWithParameter is called in session, 
we expect more type to be valid params not only boolean/float/int/string/map/list.

## How do you solve it?
On the basis of the original support types, the support for pojo, collection and time has been expanded.
The pojo type uses reflection values to convert to Map

```mermaid
graph TB
S--value-->N
N--Y_NullType-->E
N--N-->L
L--Y-->XV
XV-->E

L--N-->CV
CV-->S

CV(Collect_for / Map_for / Date: unit item)
XV(Value.xxxVal)
L{is leaf type}
S(value2Nvalue)
N{value is null}
E(return nValue)
```

## Special notes for your reviewer, ex. impact of this fix, design document, etc:


