### PR TITLE
isolate broken graphd server while client application is running

### DIFF
--- a/client/src/main/java/com/vesoft/nebula/client/graph/SessionPoolConfig.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/SessionPoolConfig.java
@@ -44,6 +44,9 @@ public class SessionPoolConfig implements Serializable {
     // interval time for retry, unit ms
     private int intervalTime = 0;
 
+    // whether reconnect when create session using a broken graphd server
+    private boolean reconnect = false;
+
 
     public SessionPoolConfig(List<HostAddress> addresses,
                              String spaceName,
@@ -180,6 +183,14 @@ public class SessionPoolConfig implements Serializable {
         return this;
     }
 
+    public boolean isReconnect() {
+        return reconnect;
+    }
+
+    public SessionPoolConfig setReconnect(boolean reconnect) {
+        this.reconnect = reconnect;
+        return this;
+    }
 
     @Override
     public String toString() {
@@ -195,6 +206,7 @@ public class SessionPoolConfig implements Serializable {
                 + ", waitTime=" + waitTime
                 + ", retryTimes=" + retryTimes
                 + ", intervalTIme=" + intervalTime
+                + ", reconnect=" + reconnect
                 + '}';
     }
 }


### PR DESCRIPTION
Isolation is config with SessionPoolConfig.setReconnect(),  the default value is false, meaning no reconnect with other available server hosts.
If reconnect is true, try all available server hosts util it connects succeed or hosts is exhausted.