### PR TITLE
support to config the version white list

### DIFF
--- a/client/src/main/java/com/vesoft/nebula/client/graph/NebulaPoolConfig.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/NebulaPoolConfig.java
@@ -50,6 +50,9 @@ public class NebulaPoolConfig implements Serializable {
     // Set custom headers for http2
     private Map<String,String> customHeaders = new HashMap<>();
 
+    // set version for client
+    private String version = null;
+
     public boolean isEnableSsl() {
         return enableSsl;
     }
@@ -145,5 +148,13 @@ public class NebulaPoolConfig implements Serializable {
     public NebulaPoolConfig setCustomHeaders(Map<String, String> customHeaders) {
         this.customHeaders = customHeaders;
         return this;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
     }
 }

--- a/client/src/main/java/com/vesoft/nebula/client/graph/SessionPool.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/SessionPool.java
@@ -351,11 +351,13 @@ public class SessionPool implements Serializable {
                     connection.open(getAddress(), sessionPoolConfig.getTimeout(),
                             sessionPoolConfig.getSslParam(),
                             sessionPoolConfig.isUseHttp2(),
-                            sessionPoolConfig.getCustomHeaders());
+                            sessionPoolConfig.getCustomHeaders(),
+                            sessionPoolConfig.getVersion());
                 } else {
                     connection.open(getAddress(), sessionPoolConfig.getTimeout(),
                             sessionPoolConfig.isUseHttp2(),
-                            sessionPoolConfig.getCustomHeaders());
+                            sessionPoolConfig.getCustomHeaders(),
+                            sessionPoolConfig.getVersion());
                 }
                 break;
             } catch (Exception e) {

--- a/client/src/main/java/com/vesoft/nebula/client/graph/SessionPoolConfig.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/SessionPoolConfig.java
@@ -63,6 +63,8 @@ public class SessionPoolConfig implements Serializable {
 
     private Map<String, String> customHeaders = new HashMap<>();
 
+    private String version = null;
+
 
     public SessionPoolConfig(List<HostAddress> addresses,
                              String spaceName,
@@ -254,6 +256,14 @@ public class SessionPoolConfig implements Serializable {
     public SessionPoolConfig setCustomHeaders(Map<String, String> customHeaders) {
         this.customHeaders = customHeaders;
         return this;
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
     }
 
     @Override

--- a/client/src/main/java/com/vesoft/nebula/client/graph/net/ConnObjectPool.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/net/ConnObjectPool.java
@@ -39,11 +39,11 @@ public class ConnObjectPool extends BasePooledObjectFactory<SyncConnection>
                         throw new IllegalArgumentException("SSL Param is required when enableSsl "
                                 + "is set to true");
                     }
-                    conn.open(address, config.getTimeout(),
-                            config.getSslParam(), config.isUseHttp2(), config.getCustomHeaders());
+                    conn.open(address, config.getTimeout(), config.getSslParam(),
+                            config.isUseHttp2(), config.getCustomHeaders(), config.getVersion());
                 } else {
                     conn.open(address, config.getTimeout(),
-                            config.isUseHttp2(), config.getCustomHeaders());
+                            config.isUseHttp2(), config.getCustomHeaders(), config.getVersion());
                 }
                 return conn;
             } catch (IOErrorException e) {

--- a/client/src/main/java/com/vesoft/nebula/client/graph/net/Connection.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/net/Connection.java
@@ -21,7 +21,8 @@ public abstract class Connection implements Serializable {
             throws IOErrorException, ClientServerIncompatibleException;
 
     public abstract void open(HostAddress address, int timeout,
-                              SSLParam sslParam, boolean isUseHttp2, Map<String, String> headers)
+                              SSLParam sslParam, boolean isUseHttp2, Map<String, String> headers,
+                              String version)
             throws IOErrorException, ClientServerIncompatibleException;
 
 
@@ -29,7 +30,7 @@ public abstract class Connection implements Serializable {
             ClientServerIncompatibleException;
 
     public abstract void open(HostAddress address, int timeout,
-                              boolean isUseHttp2, Map<String, String> headers)
+                              boolean isUseHttp2, Map<String, String> headers, String version)
             throws IOErrorException, ClientServerIncompatibleException;
 
     public abstract void reopen() throws IOErrorException, ClientServerIncompatibleException;

--- a/client/src/main/java/com/vesoft/nebula/client/graph/net/NebulaPool.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/net/NebulaPool.java
@@ -40,27 +40,27 @@ public class NebulaPool implements Serializable {
     private void checkConfig(NebulaPoolConfig config) {
         if (config.getIdleTime() < 0) {
             throw new InvalidConfigException(
-                "Config idleTime:" + config.getIdleTime() + " is illegal");
+                    "Config idleTime:" + config.getIdleTime() + " is illegal");
         }
 
         if (config.getMaxConnSize() <= 0) {
             throw new InvalidConfigException(
-                "Config maxConnSize:" + config.getMaxConnSize() + " is illegal");
+                    "Config maxConnSize:" + config.getMaxConnSize() + " is illegal");
         }
 
         if (config.getMinConnSize() < 0 || config.getMinConnSize() > config.getMaxConnSize()) {
             throw new InvalidConfigException(
-                "Config minConnSize:" + config.getMinConnSize() + " is illegal");
+                    "Config minConnSize:" + config.getMinConnSize() + " is illegal");
         }
 
         if (config.getTimeout() < 0) {
             throw new InvalidConfigException(
-                "Config timeout:" + config.getTimeout() + " is illegal");
+                    "Config timeout:" + config.getTimeout() + " is illegal");
         }
 
         if (config.getWaitTime() < 0) {
             throw new InvalidConfigException(
-                "Config waitTime:" + config.getWaitTime() + " is illegal");
+                    "Config waitTime:" + config.getWaitTime() + " is illegal");
         }
 
         if (config.getMinClusterHealthRate() < 0) {
@@ -72,23 +72,24 @@ public class NebulaPool implements Serializable {
 
     /**
      * @param addresses the graphd services addresses
-     * @param config the config for the pool
-     * @return boolean if all graph services are ok, return true,
-     *         if some of them broken return false
-     * @throws UnknownHostException if host address is illegal
+     * @param config    the config for the pool
+     * @return boolean if all graph services are ok, return true,if some of them broken return false
+     * @throws UnknownHostException   if host address is illegal
      * @throws InvalidConfigException if config is illegal
      */
     public boolean init(List<HostAddress> addresses, NebulaPoolConfig config)
-        throws UnknownHostException, InvalidConfigException {
+            throws UnknownHostException, InvalidConfigException {
         checkInit();
         hasInit.set(true);
         checkConfig(config);
         this.waitTime = config.getWaitTime();
         this.loadBalancer = config.isEnableSsl()
                 ? new RoundRobinLoadBalancer(addresses, config.getTimeout(), config.getSslParam(),
-                config.getMinClusterHealthRate(), config.isUseHttp2(), config.getCustomHeaders())
+                config.getMinClusterHealthRate(), config.isUseHttp2(), config.getCustomHeaders(),
+                config.getVersion())
                 : new RoundRobinLoadBalancer(addresses, config.getTimeout(),
-                config.getMinClusterHealthRate(),config.isUseHttp2(), config.getCustomHeaders());
+                config.getMinClusterHealthRate(), config.isUseHttp2(), config.getCustomHeaders(),
+                config.getVersion());
         ConnObjectPool objectPool = new ConnObjectPool(this.loadBalancer, config);
         this.objectPool = new GenericObjectPool<>(objectPool);
         GenericObjectPoolConfig objConfig = new GenericObjectPoolConfig();
@@ -100,11 +101,11 @@ public class NebulaPool implements Serializable {
         objConfig.setTestOnCreate(true);
         objConfig.setTestWhileIdle(true);
         objConfig.setTimeBetweenEvictionRunsMillis(config.getIntervalIdle() <= 0
-            ? BaseObjectPoolConfig.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS
-            : config.getIntervalIdle());
+                ? BaseObjectPoolConfig.DEFAULT_TIME_BETWEEN_EVICTION_RUNS_MILLIS
+                : config.getIntervalIdle());
         objConfig.setSoftMinEvictableIdleTimeMillis(config.getIdleTime() <= 0
-            ? BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS
-            : config.getIdleTime());
+                ? BaseObjectPoolConfig.DEFAULT_MIN_EVICTABLE_IDLE_TIME_MILLIS
+                : config.getIdleTime());
         this.objectPool.setConfig(objConfig);
 
         AbandonedConfig abandonedConfig = new AbandonedConfig();
@@ -127,13 +128,14 @@ public class NebulaPool implements Serializable {
 
     /**
      * get a session from the NebulaPool
-     * @param userName the userName to authenticate with nebula-graph
-     * @param password the password to authenticate with nebula-graph
+     *
+     * @param userName  the userName to authenticate with nebula-graph
+     * @param password  the password to authenticate with nebula-graph
      * @param reconnect whether to retry after the connection is disconnected
      * @return Session
      * @throws NotValidConnectionException if get connection failed
-     * @throws IOErrorException if get unexpected exception
-     * @throws AuthFailedException if authenticate failed
+     * @throws IOErrorException            if get unexpected exception
+     * @throws AuthFailedException         if authenticate failed
      */
     public Session getSession(String userName, String password, boolean reconnect)
             throws NotValidConnectionException, IOErrorException, AuthFailedException,
@@ -156,6 +158,7 @@ public class NebulaPool implements Serializable {
 
     /**
      * Get the number of connections was used by users
+     *
      * @return the active connection number
      */
     public int getActiveConnNum() {
@@ -165,6 +168,7 @@ public class NebulaPool implements Serializable {
 
     /**
      * Get the number of free connections in the pool
+     *
      * @return the idle connection number
      */
     public int getIdleConnNum() {
@@ -174,6 +178,7 @@ public class NebulaPool implements Serializable {
 
     /**
      * Get the number of waits in a waiting get connection
+     *
      * @return the waiting connection number
      */
     public int getWaitersNum() {
@@ -194,6 +199,7 @@ public class NebulaPool implements Serializable {
 
     /**
      * Set the connection is invalidate, and the object pool will destroy it
+     *
      * @param connection the invalidate connection
      */
     protected void setInvalidateConnection(SyncConnection connection) {
@@ -207,6 +213,7 @@ public class NebulaPool implements Serializable {
 
     /**
      * Return the connection to object pool
+     *
      * @param connection the return connection
      */
     protected void returnConnection(SyncConnection connection) {
@@ -226,15 +233,15 @@ public class NebulaPool implements Serializable {
     private void checkNoInit() throws RuntimeException {
         if (!hasInit.get()) {
             throw new RuntimeException(
-                "The pool has not been initialized, please initialize it first.");
+                    "The pool has not been initialized, please initialize it first.");
         }
     }
 
     private void checkInit() throws RuntimeException {
         if (hasInit.get()) {
             throw new RuntimeException(
-                "The pool has already been initialized. "
-                    + "Please do not initialize the pool repeatedly.");
+                    "The pool has already been initialized. "
+                            + "Please do not initialize the pool repeatedly.");
         }
     }
 

--- a/client/src/main/java/com/vesoft/nebula/client/graph/net/RoundRobinLoadBalancer.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/net/RoundRobinLoadBalancer.java
@@ -34,14 +34,16 @@ public class RoundRobinLoadBalancer implements LoadBalancer {
 
     private Map<String, String> customHeaders;
 
+    private String version = null;
+
     public RoundRobinLoadBalancer(List<HostAddress> addresses, int timeout,
-                                  double minClusterHealthRate) {
-        this(addresses, timeout, minClusterHealthRate, false, new HashMap<>());
+                                  double minClusterHealthRate, String version) {
+        this(addresses, timeout, minClusterHealthRate, false, new HashMap<>(), version);
     }
 
     public RoundRobinLoadBalancer(List<HostAddress> addresses, int timeout,
                                   double minClusterHealthRate, boolean useHttp2,
-                                  Map<String, String> headers) {
+                                  Map<String, String> headers, String version) {
         this.timeout = timeout;
         for (HostAddress addr : addresses) {
             this.addresses.add(addr);
@@ -50,18 +52,19 @@ public class RoundRobinLoadBalancer implements LoadBalancer {
         this.minClusterHealthRate = minClusterHealthRate;
         this.useHttp2 = useHttp2;
         this.customHeaders = headers;
+        this.version = version;
         schedule.scheduleAtFixedRate(this::scheduleTask, 0, delayTime, TimeUnit.SECONDS);
     }
 
     public RoundRobinLoadBalancer(List<HostAddress> addresses, int timeout, SSLParam sslParam,
-                                  double minClusterHealthRate) {
-        this(addresses, timeout, sslParam, minClusterHealthRate, false, new HashMap<>());
+                                  double minClusterHealthRate, String version) {
+        this(addresses, timeout, sslParam, minClusterHealthRate, false, new HashMap<>(), version);
     }
 
     public RoundRobinLoadBalancer(List<HostAddress> addresses, int timeout, SSLParam sslParam,
                                   double minClusterHealthRate, boolean useHttp2,
-                                  Map<String, String> headers) {
-        this(addresses, timeout, minClusterHealthRate, useHttp2, headers);
+                                  Map<String, String> headers, String version) {
+        this(addresses, timeout, minClusterHealthRate, useHttp2, headers, version);
         this.sslParam = sslParam;
         this.enabledSsl = true;
     }
@@ -101,9 +104,9 @@ public class RoundRobinLoadBalancer implements LoadBalancer {
         try {
             Connection connection = new SyncConnection();
             if (enabledSsl) {
-                connection.open(addr, this.timeout, sslParam, useHttp2, customHeaders);
+                connection.open(addr, this.timeout, sslParam, useHttp2, customHeaders, version);
             } else {
-                connection.open(addr, this.timeout, useHttp2, customHeaders);
+                connection.open(addr, this.timeout, useHttp2, customHeaders, version);
             }
             boolean pong = connection.ping();
             connection.close();

--- a/client/src/main/java/com/vesoft/nebula/client/meta/MetaManager.java
+++ b/client/src/main/java/com/vesoft/nebula/client/meta/MetaManager.java
@@ -64,6 +64,18 @@ public class MetaManager implements MetaCache, Serializable {
     }
 
     /**
+     * init the meta info cache with client version
+     */
+    public MetaManager(List<HostAddress> address, String version)
+            throws TException, ClientServerIncompatibleException, UnknownHostException {
+        metaClient = new MetaClient(address);
+        metaClient.setVersion(version);
+        metaClient.connect();
+        fillMetaInfo();
+    }
+
+
+    /**
      * init the meta info cache with more config
      */
     public MetaManager(List<HostAddress> address, int timeout, int connectionRetry,
@@ -71,6 +83,19 @@ public class MetaManager implements MetaCache, Serializable {
             throws TException, ClientServerIncompatibleException, UnknownHostException {
         metaClient = new MetaClient(address, timeout, connectionRetry, executionRetry, enableSSL,
                 sslParam);
+        metaClient.connect();
+        fillMetaInfo();
+    }
+
+    /**
+     * init the meta info cache with more config
+     */
+    public MetaManager(List<HostAddress> address, int timeout, int connectionRetry,
+                       int executionRetry, boolean enableSSL, SSLParam sslParam, String version)
+            throws TException, ClientServerIncompatibleException, UnknownHostException {
+        metaClient = new MetaClient(address, timeout, connectionRetry, executionRetry, enableSSL,
+                sslParam);
+        metaClient.setVersion(version);
         metaClient.connect();
         fillMetaInfo();
     }

--- a/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
+++ b/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
@@ -41,6 +41,8 @@ public class StorageClient implements Serializable {
     private boolean enableSSL = false;
     private SSLParam sslParam = null;
 
+    private String version = null;
+
     /**
      * Get a Nebula Storage client that executes the scan query to get NebulaGraph's data with
      * one server host.
@@ -92,6 +94,11 @@ public class StorageClient implements Serializable {
         }
     }
 
+    public StorageClient setVersion(String version) {
+        this.version = version;
+        return this;
+    }
+
     /**
      * Connect to Nebula Storage server.
      *
@@ -104,7 +111,7 @@ public class StorageClient implements Serializable {
         config.setSslParam(sslParam);
         pool = new StorageConnPool(config);
         metaManager = new MetaManager(addresses, timeout, connectionRetry, executionRetry,
-                enableSSL, sslParam);
+                enableSSL, sslParam, version);
         return true;
     }
 

--- a/client/src/test/java/com/vesoft/nebula/client/graph/net/TestConnectionPool.java
+++ b/client/src/test/java/com/vesoft/nebula/client/graph/net/TestConnectionPool.java
@@ -9,6 +9,7 @@ import com.vesoft.nebula.ErrorCode;
 import com.vesoft.nebula.client.graph.NebulaPoolConfig;
 import com.vesoft.nebula.client.graph.data.HostAddress;
 import com.vesoft.nebula.client.graph.data.ResultSet;
+import com.vesoft.nebula.client.graph.exception.ClientServerIncompatibleException;
 import com.vesoft.nebula.client.graph.exception.IOErrorException;
 import com.vesoft.nebula.client.graph.exception.InvalidConfigException;
 import java.net.UnknownHostException;
@@ -29,8 +30,8 @@ public class TestConnectionPool {
             NebulaPoolConfig config = new NebulaPoolConfig();
             config.setIdleTime(-10);
             pool.init(
-                Collections.singletonList(new HostAddress("127.0.0.1", 3777)),
-                config);
+                    Collections.singletonList(new HostAddress("127.0.0.1", 3777)),
+                    config);
             assert false;
         } catch (UnknownHostException e) {
             System.out.println("We expect must reach here: init pool failed.");
@@ -46,8 +47,8 @@ public class TestConnectionPool {
             NebulaPoolConfig config = new NebulaPoolConfig();
             config.setMaxConnSize(-10);
             pool.init(
-                Collections.singletonList(new HostAddress("127.0.0.1", 3777)),
-                config);
+                    Collections.singletonList(new HostAddress("127.0.0.1", 3777)),
+                    config);
             assert false;
         } catch (UnknownHostException e) {
             System.out.println("We expect must reach here: init pool failed.");
@@ -64,10 +65,10 @@ public class TestConnectionPool {
             config.setMaxConnSize(10);
             config.setMinConnSize(20);
             pool.init(
-                Collections.singletonList(new HostAddress("127.0.0.1", 3777)),
-                config);
+                    Collections.singletonList(new HostAddress("127.0.0.1", 3777)),
+                    config);
             assert false;
-        } catch (UnknownHostException  e) {
+        } catch (UnknownHostException e) {
             System.out.println("We expect must reach here: init pool failed.");
             assert false;
         } catch (InvalidConfigException e) {
@@ -81,8 +82,8 @@ public class TestConnectionPool {
             NebulaPoolConfig config = new NebulaPoolConfig();
             config.setTimeout(-10);
             pool.init(
-                Collections.singletonList(new HostAddress("127.0.0.1", 3777)),
-                config);
+                    Collections.singletonList(new HostAddress("127.0.0.1", 3777)),
+                    config);
             assert false;
         } catch (UnknownHostException e) {
             System.out.println("We expect must reach here: init pool failed.");
@@ -95,7 +96,7 @@ public class TestConnectionPool {
         // hostname is not existed
         try {
             List<HostAddress> addresses = Collections.singletonList(
-                new HostAddress("hostname", 3888));
+                    new HostAddress("hostname", 3888));
             NebulaPool pool = new NebulaPool();
             Assert.assertFalse(pool.init(addresses, new NebulaPoolConfig()));
         } catch (UnknownHostException e) {
@@ -109,12 +110,59 @@ public class TestConnectionPool {
             nebulaPoolConfig.setMinConnSize(0);
             nebulaPoolConfig.setMaxConnSize(1);
             List<HostAddress> addresses = Collections.singletonList(
-                new HostAddress("127.0.0.1", 3888));
+                    new HostAddress("127.0.0.1", 3888));
             NebulaPool pool = new NebulaPool();
             Assert.assertFalse(pool.init(addresses, nebulaPoolConfig));
         } catch (Exception e) {
             e.printStackTrace();
             Assert.fail();
+        }
+    }
+
+    @Test
+    public void testDefaultVersion() {
+        try {
+            NebulaPool pool = new NebulaPool();
+            NebulaPoolConfig config = new NebulaPoolConfig();
+            pool.init(
+                    Collections.singletonList(new HostAddress("127.0.0.1", 9669)),
+                    config);
+            assert true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            assert false;
+        }
+    }
+
+    @Test
+    public void testVersionInWhiteList() {
+        try {
+            NebulaPool pool = new NebulaPool();
+            NebulaPoolConfig config = new NebulaPoolConfig();
+            config.setVersion("test");
+            pool.init(
+                    Collections.singletonList(new HostAddress("127.0.0.1", 9669)),
+                    config);
+            assert true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            assert false;
+        }
+    }
+
+    @Test
+    public void testVersionNotInWhiteList() {
+        try {
+            NebulaPool pool = new NebulaPool();
+            NebulaPoolConfig config = new NebulaPoolConfig();
+            config.setVersion("INVALID_VERSION");
+            boolean initResult = pool.init(
+                    Collections.singletonList(new HostAddress("127.0.0.1", 9669)),
+                    config);
+            assert !initResult;
+        } catch (Exception e) {
+            e.printStackTrace();
+            assert false;
         }
     }
 
@@ -132,7 +180,7 @@ public class TestConnectionPool {
             // set wait time
             nebulaPoolConfig.setWaitTime(1000);
             List<HostAddress> addresses = Collections.singletonList(
-                new HostAddress("127.0.0.1", 9671));
+                    new HostAddress("127.0.0.1", 9671));
             pool = new NebulaPool();
             assert pool.init(addresses, nebulaPoolConfig);
             int i = 0;
@@ -157,7 +205,7 @@ public class TestConnectionPool {
             } catch (Exception e) {
                 System.out.println(e.getMessage());
                 System.out.println("We expect must reach here: get session failed.");
-                long  timeInterval = System.currentTimeMillis() - beginTime;
+                long timeInterval = System.currentTimeMillis() - beginTime;
                 System.out.println("timeInterval is " + timeInterval);
                 Assert.assertTrue(System.currentTimeMillis() - beginTime >= 1000);
                 assert (true);
@@ -202,8 +250,8 @@ public class TestConnectionPool {
             assert false;
         } catch (Exception e) {
             Assert.assertTrue(
-                e.getMessage().contains(
-                    "The pool has not been initialized, please initialize it first."));
+                    e.getMessage().contains(
+                            "The pool has not been initialized, please initialize it first."));
             System.out.println("We expect must reach here: init pool failed.");
             assert true;
         }
@@ -211,18 +259,18 @@ public class TestConnectionPool {
         // init twice
         try {
             pool.init(
-                Collections.singletonList(new HostAddress("127.0.0.1", 9669)),
-                new NebulaPoolConfig());
+                    Collections.singletonList(new HostAddress("127.0.0.1", 9669)),
+                    new NebulaPoolConfig());
             assert true;
             pool.init(
-                Collections.singletonList(new HostAddress("127.0.0.1", 9669)),
-                new NebulaPoolConfig());
+                    Collections.singletonList(new HostAddress("127.0.0.1", 9669)),
+                    new NebulaPoolConfig());
             assert false;
         } catch (Exception e) {
             Assert.assertTrue(
-                e.getMessage().contains(
-                    "The pool has already been initialized. "
-                        + "Please do not initialize the pool repeatedly"));
+                    e.getMessage().contains(
+                            "The pool has already been initialized. "
+                                    + "Please do not initialize the pool repeatedly"));
             System.out.println("We expect must reach here: init pool failed.");
             assert true;
         }
@@ -248,14 +296,14 @@ public class TestConnectionPool {
             nebulaPoolConfig.setMaxConnSize(1);
             nebulaPoolConfig.setTimeout(1000);
             List<HostAddress> addresses = Collections.singletonList(
-                new HostAddress("127.0.0.1", 9669));
+                    new HostAddress("127.0.0.1", 9669));
             pool = new NebulaPool();
             assert pool.init(addresses, nebulaPoolConfig);
             session = pool.getSession("root", "nebula", false);
             assert (session != null);
             try {
                 session.execute(
-                    "USE nba;GO 600 STEPS FROM \"Tim Duncan\" OVER like");
+                        "USE nba;GO 600 STEPS FROM \"Tim Duncan\" OVER like");
                 assert false;
             } catch (IOErrorException e) {
                 Assert.assertTrue(e.getMessage().contains("Read timed out"));

--- a/client/src/test/java/com/vesoft/nebula/client/meta/TestMetaClient.java
+++ b/client/src/test/java/com/vesoft/nebula/client/meta/TestMetaClient.java
@@ -64,6 +64,38 @@ public class TestMetaClient extends TestCase {
         }
     }
 
+
+    public void testConnectWithVersionInWhiteList() {
+        int port = 9559;
+        try {
+            MetaClient client = new MetaClient(address, port);
+            client.setVersion("3.0.0");
+            client.connect();
+
+            client.setVersion("test");
+            client.connect();
+        } catch (TException | UnknownHostException | ClientServerIncompatibleException e) {
+            e.printStackTrace();
+            assert (false);
+        }
+    }
+
+
+    public void testConnectWithVersionNotInWhiteList() {
+        int port = 9559;
+        try {
+            MetaClient client = new MetaClient(address, port);
+            client.setVersion("INVALID_VERSION");
+            client.connect();
+        } catch (ClientServerIncompatibleException e) {
+            e.printStackTrace();
+            assert (true);
+        } catch (TException | UnknownHostException e) {
+            e.printStackTrace();
+            assert (false);
+        }
+    }
+
     public void testGetSpaces() {
         try {
             List<IdName> spaces = metaClient.getSpaces();

--- a/client/src/test/java/com/vesoft/nebula/client/storage/StorageClientTest.java
+++ b/client/src/test/java/com/vesoft/nebula/client/storage/StorageClientTest.java
@@ -53,6 +53,37 @@ public class StorageClientTest {
     }
 
     @Test
+    public void testStorageClientWithVersionInWhiteList() {
+        List<HostAddress> address = Arrays.asList(new HostAddress(ip, 9559));
+        StorageClient storageClient = new StorageClient(address);
+        try {
+            storageClient.setVersion("3.0.0");
+            assert (storageClient.connect());
+
+            storageClient.setVersion("test");
+            assert (storageClient.connect());
+        } catch (Exception e) {
+            e.printStackTrace();
+            assert false;
+        }
+    }
+
+    @Test
+    public void testStorageClientWithVersionNotInWhiteList() {
+        List<HostAddress> address = Arrays.asList(new HostAddress(ip, 9559));
+        StorageClient storageClient = new StorageClient(address);
+        try {
+            storageClient.setVersion("INVALID_VERSION");
+            storageClient.connect();
+            assert false;
+        } catch (Exception e) {
+            e.printStackTrace();
+            assert (e.getMessage()
+                    .contains("Current client is not compatible with the remote server"));
+        }
+    }
+
+    @Test
     public void testScanVertexWithNoCol() {
         try {
             client.connect();

--- a/client/src/test/resources/docker-compose.yaml
+++ b/client/src/test/resources/docker-compose.yaml
@@ -242,6 +242,8 @@ services:
       - --minloglevel=0
       - --heartbeat_interval_secs=2
       - --timezone_name=+08:00:00
+      - --enable_client_white_list=true
+      - --client_white_list=3.0.0:test
     depends_on:
       - metad0
       - metad1
@@ -279,6 +281,8 @@ services:
       - --minloglevel=0
       - --heartbeat_interval_secs=2
       - --timezone_name=+08:00:00
+      - --enable_client_white_list=true
+      - --client_white_list=3.0.0:test
     depends_on:
       - metad0
       - metad1
@@ -316,6 +320,8 @@ services:
       - --minloglevel=0
       - --heartbeat_interval_secs=2
       - --timezone_name=+08:00:00
+      - --enable_client_white_list=true
+      - --client_white_list=3.0.0:test
     depends_on:
       - metad0
       - metad1
@@ -341,7 +347,7 @@ services:
   console:
     image: vesoft/nebula-console:nightly
     entrypoint: ""
-    command: 
+    command:
       - sh
       - -c
       - |

--- a/client/src/test/resources/docker-compose.yaml
+++ b/client/src/test/resources/docker-compose.yaml
@@ -16,6 +16,8 @@ services:
       - --minloglevel=0
       - --heartbeat_interval_secs=2
       - --expired_time_factor=2
+      - --enable_client_white_list=true
+      - --client_white_list=3.0.0:test
     healthcheck:
       test: ["CMD", "curl", "-f", "http://172.28.1.1:11000/status"]
       interval: 30s
@@ -52,6 +54,8 @@ services:
       - --minloglevel=0
       - --heartbeat_interval_secs=2
       - --expired_time_factor=2
+      - --enable_client_white_list=true
+      - --client_white_list=3.0.0:test
     healthcheck:
       test: ["CMD", "curl", "-f", "http://172.28.1.2:11000/status"]
       interval: 30s
@@ -88,6 +92,8 @@ services:
       - --minloglevel=0
       - --heartbeat_interval_secs=2
       - --expired_time_factor=2
+      - --enable_client_white_list=true
+      - --client_white_list=3.0.0:test
     healthcheck:
       test: ["CMD", "curl", "-f", "http://172.28.1.3:11000/status"]
       interval: 30s

--- a/examples/src/main/java/com/vesoft/nebula/examples/GraphClientExample.java
+++ b/examples/src/main/java/com/vesoft/nebula/examples/GraphClientExample.java
@@ -90,8 +90,11 @@ public class GraphClientExample {
         try {
             NebulaPoolConfig nebulaPoolConfig = new NebulaPoolConfig();
             nebulaPoolConfig.setMaxConnSize(100);
+            // optional config, default value is 3.0.0. If config other value, please make sure
+            // the NebulaGraph server has the same value in client_white_list
+            nebulaPoolConfig.setVersion("3.0.0");
             List<HostAddress> addresses = Arrays.asList(new HostAddress("127.0.0.1", 9669));
-            Boolean initResult = pool.init(addresses, nebulaPoolConfig);
+            boolean initResult = pool.init(addresses, nebulaPoolConfig);
             if (!initResult) {
                 log.error("pool init failed.");
                 return;


### PR DESCRIPTION
close https://github.com/vesoft-inc/nebula-java/issues/567
close #568 
close #569 

the new config for `version` is optional, there is no confluence for old users.

For users who need to config a special version, the usage is:

NebulaPool:
```
NebulaPoolConfig nebulaPoolConfig = new NebulaPoolConfig();
nebulaPoolConfig.setVersion("test");
```

SessionPool:
```
SessionPoolConfig sessionPoolConfig =new SessionPoolConfig(addresses, spaceName, user, password)
                        .setVersion("test");
```

MetaClient:
```
 MetaClient client = new MetaClient(address, port);
 client.setVersion("test");
```

StorageClient:
```
StorageClient storageClient = new StorageClient(address);
storageClient.setVersion("test");
```