### PR TITLE
Add storage address mapping transform

### DIFF
--- a/client/src/main/java/com/vesoft/nebula/client/meta/MetaClient.java
+++ b/client/src/main/java/com/vesoft/nebula/client/meta/MetaClient.java
@@ -10,7 +10,6 @@ import com.facebook.thrift.protocol.THeaderProtocol;
 import com.facebook.thrift.transport.THeaderTransport;
 import com.facebook.thrift.transport.TSocket;
 import com.facebook.thrift.transport.TTransportException;
-import com.google.common.base.Charsets;
 import com.vesoft.nebula.ErrorCode;
 import com.vesoft.nebula.HostAddr;
 import com.vesoft.nebula.client.graph.data.CASignedSSLParam;

--- a/client/src/main/java/com/vesoft/nebula/client/meta/MetaManager.java
+++ b/client/src/main/java/com/vesoft/nebula/client/meta/MetaManager.java
@@ -38,27 +38,27 @@ import org.slf4j.LoggerFactory;
  */
 public class MetaManager implements MetaCache, Serializable {
     private class SpaceInfo {
-        private SpaceItem                    spaceItem     = null;
-        private Map<String, TagItem>         tagItems      = new HashMap<>();
-        private Map<Integer, String>         tagIdNames    = new HashMap<>();
-        private Map<String, EdgeItem>        edgeItems     = new HashMap<>();
-        private Map<Integer, String>         edgeTypeNames = new HashMap<>();
-        private Map<Integer, List<HostAddr>> partsAlloc    = new HashMap<>();
+        private SpaceItem spaceItem = null;
+        private Map<String, TagItem> tagItems = new HashMap<>();
+        private Map<Integer, String> tagIdNames = new HashMap<>();
+        private Map<String, EdgeItem> edgeItems = new HashMap<>();
+        private Map<Integer, String> edgeTypeNames = new HashMap<>();
+        private Map<Integer, List<HostAddr>> partsAlloc = new HashMap<>();
     }
 
-    private Map<String, MetaManager.SpaceInfo>  spacesInfo  = new HashMap<>();
+    private Map<String, MetaManager.SpaceInfo> spacesInfo = new HashMap<>();
     private Map<String, Map<Integer, HostAddr>> partLeaders = null;
 
     private Map<HostAddr, HostAddr> storageAddressMapping = new ConcurrentHashMap<>();
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MetaManager.class);
 
-    private       MetaClient             metaClient;
+    private MetaClient metaClient;
     private final ReentrantReadWriteLock lock = new ReentrantReadWriteLock();
 
-    private static final int DEFAULT_TIMEOUT_MS            = 1000;
+    private static final int DEFAULT_TIMEOUT_MS = 1000;
     private static final int DEFAULT_CONNECTION_RETRY_SIZE = 3;
-    private static final int DEFAULT_EXECUTION_RETRY_SIZE  = 3;
+    private static final int DEFAULT_EXECUTION_RETRY_SIZE = 3;
 
     /**
      * init the meta info cache
@@ -77,7 +77,7 @@ public class MetaManager implements MetaCache, Serializable {
                        int executionRetry, boolean enableSSL, SSLParam sslParam)
             throws TException, ClientServerIncompatibleException, UnknownHostException {
         metaClient = new MetaClient(address, timeout, connectionRetry, executionRetry, enableSSL,
-                                    sslParam);
+                sslParam);
         metaClient.connect();
         fillMetaInfo();
     }
@@ -102,8 +102,7 @@ public class MetaManager implements MetaCache, Serializable {
     public void addStorageAddrMapping(Map<String, String> addressMap) {
         if (addressMap != null && !addressMap.isEmpty()) {
             for (Map.Entry<String, String> et : addressMap.entrySet()) {
-                storageAddressMapping.put(NetUtil.parseHostAddr(et.getKey()),
-                                          NetUtil.parseHostAddr(et.getValue()));
+                storageAddressMapping.put(NetUtil.parseHostAddr(et.getKey()), NetUtil.parseHostAddr(et.getValue()));
             }
         }
     }
@@ -123,10 +122,10 @@ public class MetaManager implements MetaCache, Serializable {
     private void fillMetaInfo() {
         try {
             Map<String, MetaManager.SpaceInfo> tempSpacesInfo = new HashMap<>();
-            List<IdName>                       spaces         = metaClient.getSpaces();
+            List<IdName> spaces = metaClient.getSpaces();
             for (IdName space : spaces) {
                 SpaceInfo spaceInfo = new SpaceInfo();
-                String    spaceName = new String(space.name);
+                String spaceName = new String(space.name);
                 SpaceItem spaceItem = metaClient.getSpace(spaceName);
                 spaceInfo.spaceItem = spaceItem;
                 List<TagItem> tags = metaClient.getTags(spaceName);
@@ -162,10 +161,10 @@ public class MetaManager implements MetaCache, Serializable {
                         for (int partId : spacesInfo.get(spaceName).partsAlloc.keySet()) {
                             if (spacesInfo.get(spaceName).partsAlloc.get(partId).size() < 1) {
                                 LOGGER.error("space {} part {} has not allocation host.",
-                                             spaceName, partId);
+                                        spaceName, partId);
                             } else {
                                 partLeaders.get(spaceName).put(partId,
-                                                               spacesInfo.get(spaceName).partsAlloc.get(partId).get(0));
+                                        spacesInfo.get(spaceName).partsAlloc.get(partId).get(0));
                             }
 
                         }

--- a/client/src/main/java/com/vesoft/nebula/client/meta/MetaManager.java
+++ b/client/src/main/java/com/vesoft/nebula/client/meta/MetaManager.java
@@ -16,7 +16,7 @@ import com.vesoft.nebula.meta.EdgeItem;
 import com.vesoft.nebula.meta.IdName;
 import com.vesoft.nebula.meta.SpaceItem;
 import com.vesoft.nebula.meta.TagItem;
-
+import com.vesoft.nebula.util.NetUtil;
 import java.io.Serializable;
 import java.net.UnknownHostException;
 import java.util.ArrayList;
@@ -28,8 +28,6 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.stream.Collectors;
-
-import com.vesoft.nebula.util.NetUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -90,7 +88,8 @@ public class MetaManager implements MetaCache, Serializable {
      */
     public void addStorageAddrMapping(String sourceAddr, String targetAddr) {
         if (sourceAddr != null && targetAddr != null) {
-            storageAddressMapping.put(NetUtil.parseHostAddr(sourceAddr), NetUtil.parseHostAddr(targetAddr));
+            storageAddressMapping.put(NetUtil.parseHostAddr(sourceAddr),
+                                      NetUtil.parseHostAddr(targetAddr));
         }
     }
 
@@ -102,7 +101,8 @@ public class MetaManager implements MetaCache, Serializable {
     public void addStorageAddrMapping(Map<String, String> addressMap) {
         if (addressMap != null && !addressMap.isEmpty()) {
             for (Map.Entry<String, String> et : addressMap.entrySet()) {
-                storageAddressMapping.put(NetUtil.parseHostAddr(et.getKey()), NetUtil.parseHostAddr(et.getValue()));
+                storageAddressMapping.put(NetUtil.parseHostAddr(et.getKey()),
+                                          NetUtil.parseHostAddr(et.getValue()));
             }
         }
     }
@@ -399,7 +399,10 @@ public class MetaManager implements MetaCache, Serializable {
             return new HashSet<>();
         }
         if (!storageAddressMapping.isEmpty()) {
-            hosts = hosts.stream().map(hostAddr -> storageAddressMapping.getOrDefault(hostAddr, hostAddr)).collect(Collectors.toSet());
+            hosts = hosts
+                    .stream()
+                    .map(hostAddr -> storageAddressMapping.getOrDefault(hostAddr, hostAddr))
+                    .collect(Collectors.toSet());
         }
         return hosts;
     }

--- a/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
+++ b/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
@@ -18,10 +18,13 @@ import com.vesoft.nebula.storage.EdgeProp;
 import com.vesoft.nebula.storage.ScanEdgeRequest;
 import com.vesoft.nebula.storage.ScanVertexRequest;
 import com.vesoft.nebula.storage.VertexProp;
-
 import java.io.Serializable;
-import java.util.*;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,11 +96,14 @@ public class StorageClient implements Serializable {
     }
 
     /**
-     * The storage address translation relationship is set to convert the storage address that cannot be obtained by requesting the meta service
+     * The storage address translation relationship is set to convert the storage address
+     * that cannot be obtained by requesting the meta service
      *
-     * @param storageAddressMapping sourceAddressFromMeta -> targetAddress,Format ip:port. eg: 127.0.0.1:9559 -> 10.1.1.2:9559，
-     *                              Translates the storage 127.0.0.1:9559 address obtained from the meta server to 10.1.1.2:9559.
-     *                              It will use 10.1.1.2:9559 to request storage.Instead of 27.0.0.1:9559
+     * @param storageAddressMapping sourceAddressFromMeta -> targetAddress,Format ip:port.
+     *                              eg: 127.0.0.1:9559 -> 10.1.1.2:9559，
+     *                              Translates the storage 127.0.0.1:9559 address obtained from the
+     *                              meta server to 10.1.1.2:9559. It will use 10.1.1.2:9559 to
+     *                              request storage. Instead of 27.0.0.1:9559
      */
     public void setStorageAddressMapping(Map<String, String> storageAddressMapping) {
         this.storageAddressMapping = storageAddressMapping;

--- a/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
+++ b/client/src/main/java/com/vesoft/nebula/client/storage/StorageClient.java
@@ -18,13 +18,10 @@ import com.vesoft.nebula.storage.EdgeProp;
 import com.vesoft.nebula.storage.ScanEdgeRequest;
 import com.vesoft.nebula.storage.ScanVertexRequest;
 import com.vesoft.nebula.storage.VertexProp;
+
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,20 +29,17 @@ public class StorageClient implements Serializable {
     private static final Logger LOGGER = LoggerFactory.getLogger(StorageClient.class);
 
     private final GraphStorageConnection connection;
-    private       StorageConnPool        pool;
-    private       MetaManager            metaManager;
-    private final List<HostAddress>      addresses;
-    private       int                    timeout         = 10000; // ms
-    private       int                    connectionRetry = 3;
-    private       int                    executionRetry  = 1;
+    private StorageConnPool pool;
+    private MetaManager metaManager;
+    private final List<HostAddress> addresses;
+    private int timeout = 10000; // ms
+    private int connectionRetry = 3;
+    private int executionRetry = 1;
 
-    private boolean  enableSSL = false;
-    private SSLParam sslParam  = null;
+    private boolean enableSSL = false;
+    private SSLParam sslParam = null;
 
     private Map<String, String> storageAddressMapping;
-
-    private String user     = null;
-    private String password = null;
 
     /**
      * Get a Nebula Storage client that executes the scan query to get NebulaGraph's data with
@@ -124,19 +118,9 @@ public class StorageClient implements Serializable {
         config.setSslParam(sslParam);
         pool = new StorageConnPool(config);
         metaManager = new MetaManager(addresses, timeout, connectionRetry, executionRetry,
-                                      enableSSL, sslParam);
+                enableSSL, sslParam);
         metaManager.addStorageAddrMapping(storageAddressMapping);
         return true;
-    }
-
-    public StorageClient setUser(String user) {
-        this.user = user;
-        return this;
-    }
-
-    public StorageClient setPassword(String password) {
-        this.password = password;
-        return this;
     }
 
 
@@ -216,7 +200,7 @@ public class StorageClient implements Serializable {
                                                List<String> returnCols,
                                                int limit) {
         return scanVertex(spaceName, tagName, returnCols, limit, DEFAULT_START_TIME,
-                          DEFAULT_END_TIME);
+                DEFAULT_END_TIME);
     }
 
     /**
@@ -237,7 +221,7 @@ public class StorageClient implements Serializable {
                                                List<String> returnCols,
                                                int limit) {
         return scanVertex(spaceName, part, tagName, returnCols, limit, DEFAULT_START_TIME,
-                          DEFAULT_END_TIME);
+                DEFAULT_END_TIME);
     }
 
     /**
@@ -272,7 +256,7 @@ public class StorageClient implements Serializable {
                                                String tagName,
                                                int limit) {
         return scanVertex(spaceName, part, tagName,
-                          limit, DEFAULT_START_TIME, DEFAULT_END_TIME);
+                limit, DEFAULT_START_TIME, DEFAULT_END_TIME);
     }
 
     /**
@@ -297,7 +281,7 @@ public class StorageClient implements Serializable {
                                                long startTime,
                                                long endTime) {
         return scanVertex(spaceName, tagName, returnCols, limit, startTime, endTime,
-                          DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
+                DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
     }
 
     /**
@@ -324,7 +308,7 @@ public class StorageClient implements Serializable {
                                                long startTime,
                                                long endTime) {
         return scanVertex(spaceName, part, tagName, returnCols, limit, startTime, endTime,
-                          DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
+                DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
     }
 
     /**
@@ -347,7 +331,7 @@ public class StorageClient implements Serializable {
                                                long startTime,
                                                long endTime) {
         return scanVertex(spaceName, tagName, limit, startTime, endTime,
-                          DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
+                DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
     }
 
     /**
@@ -371,14 +355,14 @@ public class StorageClient implements Serializable {
                                                long startTime,
                                                long endTime) {
         return scanVertex(spaceName,
-                          part,
-                          tagName,
-                          new ArrayList<>(),
-                          limit,
-                          startTime,
-                          endTime,
-                          DEFAULT_ALLOW_PART_SUCCESS,
-                          DEFAULT_ALLOW_READ_FOLLOWER);
+                part,
+                tagName,
+                new ArrayList<>(),
+                limit,
+                startTime,
+                endTime,
+                DEFAULT_ALLOW_PART_SUCCESS,
+                DEFAULT_ALLOW_READ_FOLLOWER);
     }
 
 
@@ -583,14 +567,14 @@ public class StorageClient implements Serializable {
         for (int part : parts) {
             HostAddr leader = metaManager.getLeader(spaceName, part);
             partScanInfoSet.add(new PartScanInfo(part, new HostAddress(leader.getHost(),
-                                                                       leader.getPort())));
+                    leader.getPort())));
         }
         List<HostAddress> addrs = new ArrayList<>();
         for (HostAddr addr : metaManager.listHosts()) {
             addrs.add(new HostAddress(addr.getHost(), addr.getPort()));
         }
 
-        long         tag   = metaManager.getTag(spaceName, tagName).getTag_id();
+        long tag = metaManager.getTag(spaceName, tagName).getTag_id();
         List<byte[]> props = new ArrayList<>();
         props.add("_vid".getBytes());
         if (!noColumns) {
@@ -605,9 +589,9 @@ public class StorageClient implements Serializable {
                 }
             }
         }
-        VertexProp        vertexCols  = new VertexProp((int) tag, props);
-        List<VertexProp>  vertexProps = Arrays.asList(vertexCols);
-        ScanVertexRequest request     = new ScanVertexRequest();
+        VertexProp vertexCols = new VertexProp((int) tag, props);
+        List<VertexProp> vertexProps = Arrays.asList(vertexCols);
+        ScanVertexRequest request = new ScanVertexRequest();
         request
                 .setSpace_id(getSpaceId(spaceName))
                 .setReturn_columns(vertexProps)
@@ -650,8 +634,6 @@ public class StorageClient implements Serializable {
                 .withSpaceName(spaceName)
                 .withTagName(tagName)
                 .withPartSuccess(allowPartSuccess)
-                .withUser(user)
-                .withPassword(password)
                 .build();
     }
 
@@ -731,7 +713,7 @@ public class StorageClient implements Serializable {
     public ScanEdgeResultIterator scanEdge(String spaceName, String edgeName,
                                            List<String> returnCols, int limit) {
         return scanEdge(spaceName, edgeName, returnCols, limit, DEFAULT_START_TIME,
-                        DEFAULT_END_TIME);
+                DEFAULT_END_TIME);
     }
 
     /**
@@ -749,7 +731,7 @@ public class StorageClient implements Serializable {
     public ScanEdgeResultIterator scanEdge(String spaceName, int part, String edgeName,
                                            List<String> returnCols, int limit) {
         return scanEdge(spaceName, part, edgeName, returnCols, limit, DEFAULT_START_TIME,
-                        DEFAULT_END_TIME);
+                DEFAULT_END_TIME);
     }
 
     /**
@@ -802,7 +784,7 @@ public class StorageClient implements Serializable {
                                            long startTime,
                                            long endTime) {
         return scanEdge(spaceName, edgeName, returnCols, limit, startTime, endTime,
-                        DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
+                DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
     }
 
     /**
@@ -830,7 +812,7 @@ public class StorageClient implements Serializable {
                                            long startTime,
                                            long endTime) {
         return scanEdge(spaceName, part, edgeName, returnCols, limit, startTime, endTime,
-                        DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
+                DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
     }
 
     /**
@@ -854,7 +836,7 @@ public class StorageClient implements Serializable {
                                            long startTime,
                                            long endTime) {
         return scanEdge(spaceName, edgeName, limit, startTime, endTime,
-                        DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
+                DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
     }
 
     /**
@@ -880,7 +862,7 @@ public class StorageClient implements Serializable {
                                            long startTime,
                                            long endTime) {
         return scanEdge(spaceName, part, edgeName, limit, startTime, endTime,
-                        DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
+                DEFAULT_ALLOW_PART_SUCCESS, DEFAULT_ALLOW_READ_FOLLOWER);
     }
 
 
@@ -917,7 +899,7 @@ public class StorageClient implements Serializable {
         }
 
         return scanEdge(spaceName, parts, edgeName, returnCols, false,
-                        limit, startTime, endTime, allowPartSuccess, allowReadFromFollower);
+                limit, startTime, endTime, allowPartSuccess, allowReadFromFollower);
     }
 
     /**
@@ -949,7 +931,7 @@ public class StorageClient implements Serializable {
                                            boolean allowPartSuccess,
                                            boolean allowReadFromFollower) {
         return scanEdge(spaceName, Arrays.asList(part), edgeName, returnCols, false,
-                        limit, startTime, endTime, allowPartSuccess, allowReadFromFollower);
+                limit, startTime, endTime, allowPartSuccess, allowReadFromFollower);
     }
 
 
@@ -984,7 +966,7 @@ public class StorageClient implements Serializable {
             throw new IllegalArgumentException("No valid part in space " + spaceName);
         }
         return scanEdge(spaceName, parts, edgeName, new ArrayList<>(), true,
-                        limit, startTime, endTime, allowPartSuccess, allowReadFromFollower);
+                limit, startTime, endTime, allowPartSuccess, allowReadFromFollower);
     }
 
 
@@ -1016,7 +998,7 @@ public class StorageClient implements Serializable {
                                            boolean allowPartSuccess,
                                            boolean allowReadFromFollower) {
         return scanEdge(spaceName, Arrays.asList(part), edgeName, new ArrayList<>(), true,
-                        limit, startTime, endTime, allowPartSuccess, allowReadFromFollower);
+                limit, startTime, endTime, allowPartSuccess, allowReadFromFollower);
     }
 
 
@@ -1044,7 +1026,7 @@ public class StorageClient implements Serializable {
         for (int part : parts) {
             HostAddr leader = metaManager.getLeader(spaceName, part);
             partScanInfoSet.add(new PartScanInfo(part, new HostAddress(leader.getHost(),
-                                                                       leader.getPort())));
+                    leader.getPort())));
         }
         List<HostAddress> addrs = new ArrayList<>();
         for (HostAddr addr : metaManager.listHosts()) {
@@ -1067,8 +1049,8 @@ public class StorageClient implements Serializable {
             }
         }
 
-        long           edgeId    = getEdgeId(spaceName, edgeName);
-        EdgeProp       edgeCols  = new EdgeProp((int) edgeId, props);
+        long edgeId = getEdgeId(spaceName, edgeName);
+        EdgeProp edgeCols = new EdgeProp((int) edgeId, props);
         List<EdgeProp> edgeProps = Arrays.asList(edgeCols);
 
         ScanEdgeRequest request = new ScanEdgeRequest();
@@ -1114,8 +1096,6 @@ public class StorageClient implements Serializable {
                 .withSpaceName(spaceName)
                 .withEdgeName(edgeName)
                 .withPartSuccess(allowPartSuccess)
-                .withUser(user)
-                .withPassword(password)
                 .build();
     }
 
@@ -1167,9 +1147,9 @@ public class StorageClient implements Serializable {
         return metaManager.getEdge(spaceName, edgeName).getEdge_type();
     }
 
-    private static final int     DEFAULT_LIMIT               = 1000;
-    private static final long    DEFAULT_START_TIME          = 0;
-    private static final long    DEFAULT_END_TIME            = Long.MAX_VALUE;
-    private static final boolean DEFAULT_ALLOW_PART_SUCCESS  = false;
+    private static final int DEFAULT_LIMIT = 1000;
+    private static final long DEFAULT_START_TIME = 0;
+    private static final long DEFAULT_END_TIME = Long.MAX_VALUE;
+    private static final boolean DEFAULT_ALLOW_PART_SUCCESS = false;
     private static final boolean DEFAULT_ALLOW_READ_FOLLOWER = true;
 }

--- a/client/src/main/java/com/vesoft/nebula/util/NetUtil.java
+++ b/client/src/main/java/com/vesoft/nebula/util/NetUtil.java
@@ -1,0 +1,25 @@
+package com.vesoft.nebula.util;
+
+import com.vesoft.nebula.HostAddr;
+import com.vesoft.nebula.client.graph.data.HostAddress;
+
+/**
+ * The util of network
+ *
+ * @Author jiangyiwang-jk
+ * @Date 2024/2/1 15:36
+ */
+public class NetUtil {
+
+    private NetUtil() {
+        ;
+    }
+
+    public static HostAddr parseHostAddr(String hostAddress) {
+        assert hostAddress != null : "Host address should not be null";
+        String[] hostPort = hostAddress.split(":");
+        assert hostPort.length == 2 : String.format("Invalid host address %s", hostAddress);
+        return new HostAddr(hostPort[0].trim(), Integer.parseInt(hostPort[1].trim()));
+    }
+
+}

--- a/examples/src/main/java/com/vesoft/nebula/examples/SpecialAddressStorageClientExample.java
+++ b/examples/src/main/java/com/vesoft/nebula/examples/SpecialAddressStorageClientExample.java
@@ -13,16 +13,16 @@ import com.vesoft.nebula.client.storage.scan.ScanEdgeResult;
 import com.vesoft.nebula.client.storage.scan.ScanEdgeResultIterator;
 import com.vesoft.nebula.client.storage.scan.ScanVertexResult;
 import com.vesoft.nebula.client.storage.scan.ScanVertexResultIterator;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SpecialAddressStorageClientExample {
-    private static final Logger LOGGER = LoggerFactory.getLogger(SpecialAddressStorageClientExample.class);
+    private static final Logger LOGGER =
+            LoggerFactory.getLogger(SpecialAddressStorageClientExample.class);
 
     public static void main(String[] args) {
         Map<String,String> storageAddressMapping = new HashMap<>();

--- a/examples/src/main/java/com/vesoft/nebula/examples/SpecialAddressStorageClientExample.java
+++ b/examples/src/main/java/com/vesoft/nebula/examples/SpecialAddressStorageClientExample.java
@@ -1,0 +1,123 @@
+/* Copyright (c) 2020 vesoft inc. All rights reserved.
+ *
+ * This source code is licensed under Apache 2.0 License.
+ */
+
+package com.vesoft.nebula.examples;
+
+import com.vesoft.nebula.client.storage.StorageClient;
+import com.vesoft.nebula.client.storage.data.EdgeTableRow;
+import com.vesoft.nebula.client.storage.data.VertexRow;
+import com.vesoft.nebula.client.storage.data.VertexTableRow;
+import com.vesoft.nebula.client.storage.scan.ScanEdgeResult;
+import com.vesoft.nebula.client.storage.scan.ScanEdgeResultIterator;
+import com.vesoft.nebula.client.storage.scan.ScanVertexResult;
+import com.vesoft.nebula.client.storage.scan.ScanVertexResultIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class SpecialAddressStorageClientExample {
+    private static final Logger LOGGER = LoggerFactory.getLogger(SpecialAddressStorageClientExample.class);
+
+    public static void main(String[] args) {
+        Map<String,String> storageAddressMapping = new HashMap<>();
+        storageAddressMapping.put("127.0.0.1:9559","10.xx.xx.xx:9559");
+        // input params are the metad's ip and port
+        StorageClient client = new StorageClient("127.0.0.1", 9559);
+        // set storage address mapping
+        client.setStorageAddressMapping(storageAddressMapping);
+        try {
+            client.connect();
+        } catch (Exception e) {
+            LOGGER.error("storage client connect error, ", e);
+            client.close();
+            System.exit(1);
+        }
+        scanVertex(client);
+        scanEdge(client);
+
+        client.close();
+    }
+
+    /**
+     * Vertex Person's property in Nebula Graph:
+     * first_name, last_name, gender, birthday
+     * Tom          Li        男       2010
+     */
+    public static void scanVertex(StorageClient client) {
+        ScanVertexResultIterator iterator = client.scanVertex(
+                "test",
+                "person",
+                Arrays.asList("name", "age"));
+
+        while (iterator.hasNext()) {
+            ScanVertexResult result = null;
+            try {
+                result = iterator.next();
+            } catch (Exception e) {
+                LOGGER.error("scan error, ", e);
+                client.close();
+                System.exit(1);
+            }
+            if (result.isEmpty()) {
+                continue;
+            }
+
+            List<VertexRow> vertexRows = result.getVertices();
+            for (VertexRow row : vertexRows) {
+                if (result.getVertex(row.getVid()) != null) {
+                    System.out.println(result.getVertex(row.getVid()));
+                }
+            }
+
+            System.out.println("\nresult vertex table view:");
+            System.out.println(result.getPropNames());
+            List<VertexTableRow> vertexTableRows = result.getVertexTableRows();
+            for (VertexTableRow vertex : vertexTableRows) {
+                System.out.println(vertex.getValues());
+            }
+            System.out.println("\n");
+        }
+    }
+
+    /**
+     * Edge Friend's property in Nebula Graph:
+     * degree
+     * 1.0
+     */
+    public static void scanEdge(StorageClient client) {
+        ScanEdgeResultIterator iterator = client.scanEdge(
+                "test",
+                "like",
+                Arrays.asList("likeness"));
+
+        while (iterator.hasNext()) {
+            ScanEdgeResult result = null;
+            try {
+                result = iterator.next();
+            } catch (Exception e) {
+                LOGGER.error("scan error, ", e);
+                client.close();
+                System.exit(1);
+            }
+            if (result.isEmpty()) {
+                continue;
+            }
+
+            System.out.println(result.getEdges());
+
+            System.out.println("\nresult edge table view:");
+            System.out.println(result.getPropNames());
+            List<EdgeTableRow> edgeTableRows = result.getEdgeTableRows();
+            for (EdgeTableRow edge : edgeTableRows) {
+                System.out.println(edge.getValues());
+            }
+            System.out.println("\n");
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] enhancement

## What problem(s) does this PR solve?
#### Issue(s) number: 


#### Description:
When scanning with storageClient, the storage address obtained from meta may not be used directly, such as 127.0.0.1. The code executed must be used with the storage service, but often the business code and the nebula server are not on the same machine or the same network segment. This results in the inability to scan the data using storageClient

## How do you solve it?
StorageClient initializes the Address translation relationship, and then MateManger returns address translation

## Special notes for your reviewer, ex. impact of this fix, design document, etc:
Because of runing the local nebula-client exception, the code did not run the unit tests

