### PR TITLE
fix: Byte type cannot be accurately converted to `Value`

### DIFF
--- a/client/src/main/java/com/vesoft/nebula/client/graph/net/Session.java
+++ b/client/src/main/java/com/vesoft/nebula/client/graph/net/Session.java
@@ -532,7 +532,7 @@ public class Session implements Serializable, AutoCloseable {
             put(Boolean.class, (Setter<Boolean>) Value::bVal);
             put(Integer.class, (Setter<Integer>) Value::iVal);
             put(Short.class, (Setter<Short>) Value::iVal);
-            put(Byte.class, (Setter<Short>) Value::iVal);
+            put(Byte.class, (Setter<Byte>) Value::iVal);
             put(Long.class, (Setter<Long>) Value::iVal);
             put(Float.class, (Setter<Float>) Value::fVal);
             put(Double.class, (Setter<Double>) Value::fVal);


### PR DESCRIPTION
<!--
Thanks for your contribution!
In order to review PR more efficiently, please add information according to the template.
-->

## What type of PR is this?
- [x] bug
- [ ] feature
- [ ] enhancement

## What problem(s) does this PR solve?
#### Description:
When passing Byte type in the parameter, it is mistakenly packaged as Short and cannot match the type of the database column.


