### PR TITLE
Remove Fastjson from the driver

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -25,7 +25,6 @@
         <commons-codec.version>1.13</commons-codec.version>
         <commons-pool2.version>2.2</commons-pool2.version>
         <servlet.version>3.0.1</servlet.version>
-        <fastjson.version>1.2.83</fastjson.version>
         <bouncycastle.version>1.69</bouncycastle.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <jts.version>1.16.1</jts.version>
@@ -81,11 +80,6 @@
             <version>${servlet.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.alibaba</groupId>
-            <artifactId>fastjson</artifactId>
-            <version>${fastjson.version}</version>
-        </dependency>
-        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <version>${bouncycastle.version}</version>
@@ -98,22 +92,22 @@
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-netty-shaded</artifactId>
-            <version>1.60.0</version>
+            <version>1.75.0</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-protobuf</artifactId>
-            <version>1.60.0</version>
+            <version>1.75.0</version>
         </dependency>
         <dependency>
             <groupId>io.grpc</groupId>
             <artifactId>grpc-stub</artifactId>
-            <version>1.60.0</version>
+            <version>1.75.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
-            <version>3.25.1</version>
+            <version>3.25.5</version>
         </dependency>
         <!-- https://mvnrepository.com/artifact/javax.annotation/javax.annotation-api -->
         <dependency>
@@ -192,9 +186,9 @@
                 <artifactId>protobuf-maven-plugin</artifactId>
                 <version>0.6.1</version>
                 <configuration>
-                    <protocArtifact>com.google.protobuf:protoc:3.25.1:exe:${os.detected.classifier}</protocArtifact>
+                    <protocArtifact>com.google.protobuf:protoc:3.25.5:exe:${os.detected.classifier}</protocArtifact>
                     <pluginId>grpc-java</pluginId>
-                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.60.0:exe:${os.detected.classifier}</pluginArtifact>
+                    <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.75.0:exe:${os.detected.classifier}</pluginArtifact>
                 </configuration>
                 <executions>
                     <execution>

--- a/client/src/main/java/com/vesoft/nebula/driver/graph/net/GrpcConnection.java
+++ b/client/src/main/java/com/vesoft/nebula/driver/graph/net/GrpcConnection.java
@@ -7,7 +7,6 @@ package com.vesoft.nebula.driver.graph.net;
 
 import static com.vesoft.nebula.driver.graph.exception.IOErrorException.E_TIME_OUT;
 
-import com.alibaba.fastjson.JSON;
 import com.google.common.base.Charsets;
 import com.google.protobuf.ByteString;
 import com.vesoft.nebula.driver.graph.ErrorCode;
@@ -30,6 +29,7 @@ import io.grpc.StatusRuntimeException;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
 import java.nio.charset.Charset;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLException;
 import org.slf4j.Logger;
@@ -108,7 +108,7 @@ public class GrpcConnection extends Connection {
                     .build();
             ByteString userString = user == null ? ByteString.copyFrom("", charset)
                     : ByteString.copyFrom(user, charset);
-            String authInfoString = JSON.toJSONString(authOptions);
+            String authInfoString = toJsonString(authOptions);
             AuthRequest authReq = AuthRequest.newBuilder()
                     .setUsername(userString)
                     .setAuthInfo(ByteString.copyFrom(authInfoString, charset))
@@ -138,6 +138,61 @@ public class GrpcConnection extends Connection {
             }
             throw e;
         }
+    }
+
+    static String toJsonString(Map<String, Object> options) {
+        if (options == null) {
+            return "null";
+        }
+        StringBuilder json = new StringBuilder("{");
+        boolean first = true;
+        for (Entry<String, Object> entry : options.entrySet()) {
+            if (!first) {
+                json.append(',');
+            }
+            appendJsonString(json, entry.getKey());
+            json.append(':');
+            appendJsonString(json, String.valueOf(entry.getValue()));
+            first = false;
+        }
+        return json.append('}').toString();
+    }
+
+    private static void appendJsonString(StringBuilder json, String value) {
+        json.append('"');
+        for (int index = 0; index < value.length(); index++) {
+            char character = value.charAt(index);
+            switch (character) {
+                case '"':
+                    json.append("\\\"");
+                    break;
+                case '\\':
+                    json.append("\\\\");
+                    break;
+                case '\b':
+                    json.append("\\b");
+                    break;
+                case '\f':
+                    json.append("\\f");
+                    break;
+                case '\n':
+                    json.append("\\n");
+                    break;
+                case '\r':
+                    json.append("\\r");
+                    break;
+                case '\t':
+                    json.append("\\t");
+                    break;
+                default:
+                    if (character < 0x20) {
+                        json.append(String.format("\\u%04x", (int) character));
+                    } else {
+                        json.append(character);
+                    }
+            }
+        }
+        json.append('"');
     }
 
     public ExecuteResponse execute(long sessionID, String stmt, long timeout)


### PR DESCRIPTION
Removes the Fastjson dependency from the Java driver and replaces authentication-option serialization with a local JSON serializer for string values.

Also includes the previously validated security upgrades:
- gRPC runtime and generator: 1.75.0
- Protobuf runtime and protoc: 3.25.5

Validation: `mvn -pl client -DskipTests compile`